### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Sandstorm will be documented in this file.
 
+## [0.8.1] - 2026-03-12
+
+### Features
+
+- add Notion, Firecrawl, Exa, and GitHub toolpacks (#46)
+
+### Bug Fixes
+
+- fix Linear toolpack — migrate from removed `@modelcontextprotocol/server-linear` to `linear-mcp`
+
 ## [0.8.0] - 2026-03-11
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duvo-sandstorm"
-version = "0.8.0"
+version = "0.8.1"
 description = "Open-source runtime for general-purpose AI agents in isolated sandboxes."
 keywords = ["ai-agents", "anthropic", "claude", "e2b", "fastapi", "openrouter", "sandbox", "slack"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump version to 0.8.1
- Update CHANGELOG.md

### What's in v0.8.1

- **feat:** add Notion, Firecrawl, Exa, and GitHub toolpacks (#46)
- **fix:** migrate Linear toolpack from removed `@modelcontextprotocol/server-linear` to `linear-mcp`

## Test plan

- [x] Version bumped in `pyproject.toml`
- [x] CHANGELOG updated
- After merge: `gh release create v0.8.1` triggers PyPI publish via Trusted Publishing