### PR TITLE
v0.9.0: Slack-native agents, memory, replay, TypeScript client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to Sandstorm will be documented in this file.
 
+## [0.9.0] - 2026-04-17
+
+### Bug Fixes
+
+- address /code-reviewer findings (H1–H3, M1, M3, L1, L2)
+
+### Documentation
+
+- README rewrite + comparison/FAQ/multi-llm/memory/replay
+- Langfuse/Phoenix/Langsmith setup + local compose
+
+### Features
+
+- TypeScript client @duvo/sandstorm-client
+- code-review starter for GitHub PR review agents
+- Railway template + Dockerfile polish
+- ds upgrade — in-place PyPI upgrade with template-rebuild prompt
+- polish ds slack setup + add ds slack verify
+- ds doctor preflight checks
+- inline tool breadcrumbs for @mention streaming
+- pause instead of keep-alive for Slack thread continuity
+- resume Agent SDK sessions across thread messages
+- ds replay with session fork, budget cap, markdown report
+- slash commands /remember /forget /memories /model
+- inject user memory into system_prompt at query time
+- add user-scoped MemoryStore mirroring RunStore
+- extend Run dataclass with replay/resume fields
+
+### Miscellaneous
+
+- upgrade Agent SDK to 0.2.112 and E2B to 2.20
+
+### Refactoring
+
+- fixes from /simplify review
+
 ## [0.8.1] - 2026-03-12
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM python:3.12-slim
+FROM python:3.13-slim-bookworm
 
 WORKDIR /app
 
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ src/
 
-RUN pip install --no-cache-dir .
+# Install with slack + telemetry extras so the default container can run the
+# Slack bot out of the box and export OTel traces. Users who don't need them
+# just ignore the extra deps.
+RUN pip install --no-cache-dir ".[slack,telemetry]"
 
 RUN useradd --create-home appuser
 USER appuser

--- a/README.md
+++ b/README.md
@@ -1,159 +1,196 @@
 # Sandstorm
 
-Open-source runtime for general-purpose AI agents in isolated sandboxes.
+**Claude Agent SDK, or any LLM, as a sandboxed agent in your Slack, on your infra.**
 
-CLI, API, Python client, and Slack with streaming, file uploads, and config-driven behavior.
-
-Built on the Claude Agent SDK and E2B.
+CLI, HTTP API, Python client, Slack bot, and TypeScript client over the same runtime.
+Fresh E2B sandbox per thread, streaming, file uploads, replay, and OpenTelemetry traces
+out of the box.
 
 [![CI](https://github.com/tomascupr/sandstorm/actions/workflows/ci.yml/badge.svg)](https://github.com/tomascupr/sandstorm/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/duvo-sandstorm.svg)](https://pypi.org/project/duvo-sandstorm/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/sandstorm)
 
-Sandstorm is for people who want real agent work, not a chat wrapper:
+## Why this exists
 
-- Research Acme's competitors, crawl their sites and recent news, and write a one-page branded briefing PDF with sources
-- Analyze uploaded transcripts or PDFs
-- Triage incoming support tickets
-- Run a security audit in a fresh sandbox
-- Turn docs into a draft API spec
+Anthropic shipped **Claude Managed Agents** (April 2026): great sandbox,
+Anthropic-infra only, Claude-only. Vercel shipped **Slack Agent Skill + Chat
+SDK**: great Slack wizard, Vercel-only, TypeScript-only. Neither runs on your
+infrastructure; neither gives you other LLMs; neither emits to your
+observability backend.
 
-## Terminal demo
+Sandstorm is the intersection. Self-hosted, multi-provider, Slack-native,
+observable. The shortest path from `pip install` to a production agent that
+runs on your terms.
+
+## Who it's for
+
+- Teams who want Claude-style agents in Slack but can't send runtime traffic
+  to Anthropic or Vercel.
+- Engineers on GPT-5 / Gemini / DeepSeek / Qwen / Kimi / Grok who still want
+  the Claude Agent SDK's tool + skill + sandbox story.
+- Anyone running Langfuse / Phoenix / Langsmith who refuses to operate blind
+  because their agent vendor keeps telemetry in a closed console.
+
+## What a run looks like
 
 ```bash
-$ pip install duvo-sandstorm
-$ ds init research-brief
-$ cd research-brief
-$ ds "Research Acme's competitors, crawl their sites and recent news, and write a one-page branded briefing PDF with sources."
+$ ds init research-brief && cd research-brief
+$ ds "Research Acme's competitors, crawl their sites and recent news, and write a one-page briefing PDF with sources."
 
-WEBFETCH competitor sites, product pages, and recent coverage
-STREAM compared launches, pricing, positioning, and buyer signals
-WRITE briefing.pdf
-WRITE reports/sources.md
+[tool: WebFetch]  competitor product pages + recent coverage
+[tool: WebSearch] launches, pricing, positioning, buyer signals
+[tool: Write]     briefing.pdf
+[tool: Write]     reports/sources.md
+
+--- Result: success | turns: 14 | cost: $0.0731 ---
 
 artifacts:
   - briefing.pdf
   - reports/sources.md
 ```
 
-The point is not that an agent can answer a question. It starts from a runnable starter, gets a
-fresh sandbox, can read uploads or crawl the web, writes artifacts like `briefing.pdf`, streams
-its work, and tears itself down when the run is done.
+Same prompt from Slack:
 
-## 60-second path
+```
+you:       @Sandstorm research Acme's competitors and post the briefing here
+bot:       (paused thread sandbox resumed)
+           🔧 WebFetch
+           🔧 WebSearch
+           🔧 Write
+           Acme's top three competitors are ...
+           [briefing.pdf uploaded]
+           Model: sonnet | Turns: 14 | Cost: $0.0731 | Duration: 47.2s
+```
+
+## Three things only OSS can do
+
+1. **Self-host**: runs on your Railway/Fly/K8s/Docker. Data stays in your network.
+   E2B is available self-hosted; Anthropic's Managed Agents are Anthropic-infra only.
+2. **Every LLM**: Anthropic direct, OpenRouter (GPT-5, Gemini, DeepSeek, Qwen, Kimi,
+   Grok), Vertex AI, Bedrock, Azure Foundry, any OpenAI-compatible base URL.
+3. **Your observability**: OTel export to [Langfuse](docs/observability.md),
+   Phoenix/Arize, Langsmith, or any OTLP backend. No vendor console.
+
+## Sandstorm vs the closed alternatives
+
+| Feature                    | Sandstorm | Claude Managed Agents | Vercel Slack Agent Skill | claude-code-slack-bot |
+| -------------------------- | :-------: | :-------------------: | :----------------------: | :-------------------: |
+| Self-hosted                |     ✅     |           ❌           |             ❌            |        ✅ (local)      |
+| Sandboxed per thread       |     ✅     |           ✅           |             ✅            |           ❌           |
+| Slack in the box           |     ✅     |           ❌           |             ✅            |           ✅           |
+| Multi-provider (not just Claude) | ✅   |           ❌           |             ✅            |           ❌           |
+| OTel traces to any backend |     ✅     |           ❌           |             ❌            |           ❌           |
+| OSS license                |   MIT     |        Proprietary    |        Apache templates  |          MIT          |
+| Ships a TypeScript client  |     ✅     |           ✅           |             ✅            |           ❌           |
+| Session resume + replay    |     ✅     |           ✅           |             ❌            |           ❌           |
+
+Full side-by-side in [docs/comparison.md](docs/comparison.md);
+"when should I pick each?" in [docs/faq-vs-managed-agents.md](docs/faq-vs-managed-agents.md).
+
+## 60-second quickstart
 
 ```bash
 pip install duvo-sandstorm
-ds init
-cd general-assistant
-ds add linear
-ds "Compare Notion, Coda, and Slite for async product teams"
-```
-
-`ds init` scaffolds a runnable starter with `sandstorm.json`, a starter README, `.env.example`,
-and any starter-specific assets. If provider settings are missing, the guided flow asks once and
-writes `.env` for you.
-
-Direct forms:
-
-```bash
-ds init --list
+ds doctor                  # verify creds before running anything
 ds init research-brief
-ds init security-audit my-audit
+cd research-brief
+ds "Research Acme's competitors, crawl their sites, write a one-page brief with sources"
 ```
 
-## Install extras
+`ds doctor` is the fastest way to catch a missing `ANTHROPIC_API_KEY` / `E2B_API_KEY` /
+Slack scope before your first real query.
 
-Install the base package for the CLI and server:
+## In Slack
 
 ```bash
-pip install duvo-sandstorm
+pip install "duvo-sandstorm[slack]"
+ds slack setup             # interactive, opens Slack app install in your browser
+ds slack start             # Socket Mode (dev), use --http for production
 ```
 
-Add extras only when you need them:
+Once installed:
 
-```bash
-pip install "duvo-sandstorm[client]"      # Async Python client
-pip install "duvo-sandstorm[slack]"       # Slack bot support
-pip install "duvo-sandstorm[telemetry]"   # OpenTelemetry integration
-```
+- `@Sandstorm review PR 123 in owner/repo`: agent picks up context, runs tests, posts review
+- `/remember shipping address is Berlin`: persisted per-user, per-workspace memory
+- `/forget shipping address`: case-insensitive substring delete
+- `/memories`: list what the bot remembers
+- `/model claude-haiku-4-5-20251001`: per-thread model override
+
+Thread continuity is real: each thread keeps its own paused E2B sandbox, so uploaded files,
+generated outputs, and installed packages survive across messages, even across server restarts.
+See [docs/memory.md](docs/memory.md).
 
 ## Pick a starter
 
-| Starter | Use it when you want to | Typical output | Aliases |
-|---------|--------------------------|----------------|---------|
-| `general-assistant` | Start with one flexible agent for mixed workflows | concise answer, plan, or artifact | - |
-| `research-brief` | Research a topic, compare options, and support a decision | brief with findings, recommendations, and sources | `competitive-analysis` |
-| `document-analyst` | Review transcripts, reports, PDFs, or decks | summary, risks, action items, open questions | - |
-| `support-triage` | Triage support tickets or issue exports | prioritized queue with owners and next steps | `issue-triage` |
-| `api-extractor` | Crawl docs and draft an API summary plus spec | endpoint summary and draft `openapi.yaml` | `docs-to-openapi` |
-| `security-audit` | Run a structured security review | vulnerability report with remediation steps | - |
+| Starter             | Use when…                                                       | Aliases |
+| ------------------- | --------------------------------------------------------------- | ------- |
+| `general-assistant` | One flexible agent for mixed workflows                           |     |
+| `research-brief`    | Research a topic, compare options, support a decision            | `competitive-analysis` |
+| `document-analyst`  | Review transcripts, reports, PDFs, or decks                      |     |
+| `support-triage`    | Triage tickets into priorities, owners, next actions              | `issue-triage` |
+| `api-extractor`     | Crawl docs and draft an API summary + OpenAPI spec               | `docs-to-openapi` |
+| `security-audit`    | Structured security review with sub-agents and an OWASP skill    |     |
+| `code-review`       | Review GitHub PRs with the GitHub MCP, inline comments, CI logs | `pr-review` |
 
-Need CRM access, ticket systems, or internal APIs? Add custom tools to the sandbox.
+`ds init --list` for the current catalog.
 
 ## Add toolpacks
 
-Use `ds add` to install bundled MCP integrations into the current project:
-
 ```bash
-ds add --list              # Show all available toolpacks
-ds add linear              # Issue tracking via Linear
-ds add notion              # Knowledge base via Notion
-ds add firecrawl           # Web scraping via Firecrawl
-ds add exa                 # AI-powered search via Exa
-ds add github              # GitHub repos, issues, and PRs
+ds add --list      # available: linear, notion, firecrawl, exa, github
+ds add linear
+ds add github
 ```
 
-Each command updates `sandstorm.json`, writes the required API key to `.env` and `.env.example`,
-and future CLI/API/Slack runs from that project expose the MCP server in the sandboxed agent
-runtime.
+Each command wires the MCP server into `sandstorm.json`, seeds `.env.example` with the
+required API key, and makes the tools available to CLI / API / Slack runs from that project.
 
-If the project already has a different entry for that MCP server, `ds add` stops instead
-of overwriting it. Re-run with `--force` to replace the existing config.
+## Replay a run with a different model
 
-## Why Sandstorm exists
+```bash
+ds replay <run_id> --model claude-haiku-4-5-20251001 --budget 0.05
+```
 
-Most agent projects break down in one of two ways:
+Forks the original agent session so the replay starts with identical context but on a fresh
+branch. A fast, cheap way to A/B compare models or reproduce bug-report runs. Reports
+cost Δ, latency Δ, and turn-count Δ as a markdown table. Details in [docs/replay.md](docs/replay.md).
 
-- You wire the SDK yourself and end up rebuilding sandbox lifecycle, file uploads, streaming,
-  config loading, and starter setup.
-- You use an agent framework that is good at orchestration but weak at actually shipping a
-  runnable agent product path.
+## Install extras
 
-Sandstorm is opinionated about the missing middle:
+```bash
+pip install duvo-sandstorm                    # CLI + server
+pip install "duvo-sandstorm[client]"          # Async Python client
+pip install "duvo-sandstorm[slack]"           # Slack bot
+pip install "duvo-sandstorm[telemetry]"       # OpenTelemetry
+```
 
-- starter to runnable project in one command
-- fresh sandbox per request with teardown by default
-- CLI, API, and Slack over the same runtime
-- config-driven behavior through `sandstorm.json`
-- built-in document tooling for PDF, DOCX, and PPTX workflows
+TypeScript client: `npm install @duvo/sandstorm-client` (see [clients/typescript](clients/typescript)).
 
-## Why not wire the SDK yourself?
+## Deploy
 
-| Capability | Sandstorm | Raw SDK + E2B | DIY runner |
-|------------|-----------|---------------|------------|
-| Fresh sandbox per request | Built in | Manual wiring | Manual wiring |
-| Streaming API endpoint | Built in | Manual wiring | Custom work |
-| File uploads | Built in | Manual wiring | Custom work |
-| `sandstorm.json` config layer | Built in | No | Custom work |
-| Slack bot integration | Built in | No | Custom work |
-| Starter scaffolding with `ds init` | Built in | No | Custom work |
+- **Railway**: one-click [template](deploy/railway.json), 30-second deploy
+- **Docker**: `Dockerfile` in repo root, `docker-compose.yml` for local
+- **Self-host**: `pipx install duvo-sandstorm && ds serve`
+- **Langfuse-bundled local stack**: `docker compose -f deploy/docker-compose.langfuse.yml up`
 
 ## Docs
 
 - [Getting started](docs/getting-started.md)
-- [Python client](docs/client.md)
-- [Configuration](docs/configuration.md)
-- [API reference](docs/api.md)
-- [Slack bot](docs/slack.md)
-- [Deployment](docs/deployment.md)
-- [OpenRouter](docs/openrouter.md)
-- [Advanced examples](examples/README.md)
+- [Comparison vs Managed Agents / Victor / others](docs/comparison.md)
+- [When to pick which (FAQ)](docs/faq-vs-managed-agents.md)
+- [Multi-LLM: GPT-5, Gemini, DeepSeek, Ollama, self-hosted](docs/multi-llm.md)
+- [Observability: Langfuse, Phoenix, Langsmith](docs/observability.md)
+- [Memory: `/remember`, `/forget`, persistence guarantees](docs/memory.md)
+- [Replay](docs/replay.md)
+- [Python client](docs/client.md) · [TypeScript client](clients/typescript/README.md)
+- [Configuration](docs/config.md) · [API reference](docs/api.md)
+- [Slack bot](docs/slack.md) · [Deployment](docs/deployment.md) · [OpenRouter](docs/openrouter.md)
 
 ## Community
 
-If Sandstorm saves you runner plumbing, please [star the repo](https://github.com/tomascupr/sandstorm).
-
-If you want a new starter, a provider integration, or a sharper deploy story, open an issue or
-start a discussion.
+If Sandstorm closes a gap for you, [star the repo](https://github.com/tomascupr/sandstorm)
+and [open an issue](https://github.com/tomascupr/sandstorm/issues) or
+[discussion](https://github.com/tomascupr/sandstorm/discussions) with your use case.
+We read every one.

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,73 @@
+# @duvo/sandstorm-client
+
+Thin TypeScript client for the [Sandstorm](https://github.com/tomascupr/sandstorm)
+agent runtime — stream agent runs over SSE, list prior runs, check health.
+Zero runtime dependencies (uses global `fetch`).
+
+## Install
+
+```bash
+npm install @duvo/sandstorm-client
+# or
+pnpm add @duvo/sandstorm-client
+```
+
+Requires Node 18+ (or any runtime with a global `fetch`).
+
+## Quick start
+
+```ts
+import { SandstormClient } from "@duvo/sandstorm-client";
+
+const client = new SandstormClient({
+  baseUrl: "http://localhost:8000",
+  apiKey: process.env.SANDSTORM_API_KEY, // optional — only when server auth is on
+});
+
+for await (const event of client.query({
+  prompt: "Summarize the changelog at https://github.com/vercel/next.js/releases",
+  model: "sonnet",
+})) {
+  if (event.json && typeof event.json === "object") {
+    const msg = event.json as { type?: string; message?: unknown };
+    if (msg.type === "assistant") console.log(msg.message);
+  }
+}
+```
+
+## API
+
+### `new SandstormClient(options)`
+
+| Option    | Type                      | Required | Notes                                     |
+| --------- | ------------------------- | -------- | ----------------------------------------- |
+| `baseUrl` | `string`                  | yes      | e.g. `http://localhost:8000`              |
+| `apiKey`  | `string`                  | no       | Sent as `Authorization: Bearer ...`       |
+| `fetch`   | `typeof fetch`            | no       | Custom fetch impl (tests, custom agents)  |
+
+### `client.query(request): AsyncIterable<SSEEvent>`
+
+Streams the agent run. `SSEEvent.data` is the raw JSON line from the Agent
+SDK runner; `SSEEvent.json` is the parsed object (or `null` for non-JSON
+keepalives). Mirrors `POST /query`.
+
+### `client.listRuns(limit?): Promise<Run[]>`
+
+Returns the most recent runs, newest first. Mirrors `GET /runs`.
+
+### `client.health(): Promise<HealthResponse>`
+
+Mirrors `GET /health`.
+
+## Types
+
+All request and response types are re-exported from the entry point —
+`QueryRequest`, `Run`, `SSEEvent`, `HealthResponse`, `ClientOptions`.
+
+## Examples
+
+See `examples/chat.ts` for a minimal CLI-style example.
+
+## License
+
+MIT

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,7 +1,7 @@
 # @duvo/sandstorm-client
 
 Thin TypeScript client for the [Sandstorm](https://github.com/tomascupr/sandstorm)
-agent runtime — stream agent runs over SSE, list prior runs, check health.
+agent runtime, stream agent runs over SSE, list prior runs, check health.
 Zero runtime dependencies (uses global `fetch`).
 
 ## Install
@@ -21,7 +21,7 @@ import { SandstormClient } from "@duvo/sandstorm-client";
 
 const client = new SandstormClient({
   baseUrl: "http://localhost:8000",
-  apiKey: process.env.SANDSTORM_API_KEY, // optional — only when server auth is on
+  apiKey: process.env.SANDSTORM_API_KEY, // optional, only when server auth is on
 });
 
 for await (const event of client.query({
@@ -61,7 +61,7 @@ Mirrors `GET /health`.
 
 ## Types
 
-All request and response types are re-exported from the entry point —
+All request and response types are re-exported from the entry point 
 `QueryRequest`, `Run`, `SSEEvent`, `HealthResponse`, `ClientOptions`.
 
 ## Examples

--- a/clients/typescript/examples/chat.ts
+++ b/clients/typescript/examples/chat.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal CLI example. Run against a local `ds serve`:
+ *
+ *   ds serve                           # in one terminal
+ *   pnpm install
+ *   pnpm tsx examples/chat.ts "your prompt here"
+ */
+import { SandstormClient } from "../src/index.js";
+
+async function main() {
+  const prompt = process.argv.slice(2).join(" ") || "Say hello";
+  const client = new SandstormClient({
+    baseUrl: process.env.SANDSTORM_URL ?? "http://localhost:8000",
+    apiKey: process.env.SANDSTORM_API_KEY,
+  });
+
+  for await (const event of client.query({ prompt })) {
+    if (!event.json || typeof event.json !== "object") continue;
+    const msg = event.json as {
+      type?: string;
+      message?: { content?: Array<{ type: string; text?: string }> };
+      subtype?: string;
+      error?: string;
+    };
+    if (msg.type === "assistant") {
+      for (const block of msg.message?.content ?? []) {
+        if (block.type === "text" && block.text) {
+          process.stdout.write(block.text);
+        }
+      }
+    } else if (msg.type === "error") {
+      process.stderr.write(`\nError: ${msg.error}\n`);
+      process.exit(1);
+    } else if (msg.type === "result") {
+      process.stdout.write(`\n\n--- Result: ${msg.subtype} ---\n`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@duvo/sandstorm-client",
+  "version": "0.1.0",
+  "description": "TypeScript client for the Sandstorm agent runtime — stream agent runs, manage memory, replay past runs.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tomascupr/sandstorm.git",
+    "directory": "clients/typescript"
+  },
+  "homepage": "https://github.com/tomascupr/sandstorm#readme",
+  "bugs": "https://github.com/tomascupr/sandstorm/issues",
+  "keywords": ["sandstorm", "agent", "claude", "sse", "ai-agents"],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "node --test src/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -70,6 +70,11 @@ export class SandstormClient {
   }
 
   async listRuns(limit = 50): Promise<Run[]> {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+      throw new Error(
+        `listRuns: limit must be an integer between 1 and 1000 (got ${limit})`,
+      );
+    }
     const resp = await this.fetchImpl(
       `${this.baseUrl}/runs?limit=${encodeURIComponent(limit)}`,
       {

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * @duvo/sandstorm-client
+ *
+ * Minimal TypeScript client for Sandstorm — stream agent runs over SSE, manage
+ * memory via slash-command-equivalent endpoints, replay past runs.
+ *
+ * Example:
+ *   const client = new SandstormClient({ baseUrl: "http://localhost:8000" });
+ *   for await (const event of client.query({ prompt: "say hello" })) {
+ *     console.log(event.data);
+ *   }
+ */
+
+import type {
+  ClientOptions,
+  HealthResponse,
+  QueryRequest,
+  Run,
+  SSEEvent,
+} from "./types.js";
+
+export * from "./types.js";
+
+export class SandstormClient {
+  readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: ClientOptions) {
+    if (!options.baseUrl) {
+      throw new Error("SandstormClient: baseUrl is required");
+    }
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.apiKey = options.apiKey;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error(
+        "SandstormClient: no fetch available — pass options.fetch or upgrade to Node 18+",
+      );
+    }
+  }
+
+  /** Stream an agent run as Server-Sent Events. */
+  async *query(request: QueryRequest): AsyncIterable<SSEEvent> {
+    const resp = await this.fetchImpl(`${this.baseUrl}/query`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+      },
+      body: JSON.stringify(request),
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`POST /query failed: ${resp.status} ${resp.statusText} — ${body}`);
+    }
+    if (!resp.body) {
+      throw new Error("POST /query returned no body");
+    }
+    yield* parseSSEStream(resp.body);
+  }
+
+  async health(): Promise<HealthResponse> {
+    const resp = await this.fetchImpl(`${this.baseUrl}/health`);
+    if (!resp.ok) {
+      throw new Error(`GET /health failed: ${resp.status} ${resp.statusText}`);
+    }
+    return (await resp.json()) as HealthResponse;
+  }
+
+  async listRuns(limit = 50): Promise<Run[]> {
+    const resp = await this.fetchImpl(
+      `${this.baseUrl}/runs?limit=${encodeURIComponent(limit)}`,
+      {
+        headers: this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {},
+      },
+    );
+    if (!resp.ok) {
+      throw new Error(`GET /runs failed: ${resp.status} ${resp.statusText}`);
+    }
+    return (await resp.json()) as Run[];
+  }
+}
+
+/** Parse an SSE response body into typed events. */
+async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncIterable<SSEEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const rawEvent = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const parsed = parseSSEEvent(rawEvent);
+        if (parsed) yield parsed;
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseSSEEvent(raw: string): SSEEvent | null {
+  const lines = raw.split(/\r?\n/);
+  let data = "";
+  let event: string | undefined;
+  for (const line of lines) {
+    if (!line || line.startsWith(":")) continue; // comments / keepalives
+    if (line.startsWith("data:")) {
+      data += line.slice(5).trimStart();
+    } else if (line.startsWith("event:")) {
+      event = line.slice(6).trim();
+    }
+  }
+  if (!data) return null;
+  let json: unknown = null;
+  try {
+    json = JSON.parse(data);
+  } catch {
+    // non-JSON SSE payload — leave `json` null
+  }
+  return { data, json, event };
+}

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -109,22 +109,26 @@ async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncIterable<
 
 function parseSSEEvent(raw: string): SSEEvent | null {
   const lines = raw.split(/\r?\n/);
-  let data = "";
+  const dataLines: string[] = [];
   let event: string | undefined;
   for (const line of lines) {
     if (!line || line.startsWith(":")) continue; // comments / keepalives
     if (line.startsWith("data:")) {
-      data += line.slice(5).trimStart();
+      // Per SSE spec: strip a single leading space after the colon; multiple
+      // data lines are joined with "\n" to reconstruct multi-line payloads.
+      const raw = line.slice(5);
+      dataLines.push(raw.startsWith(" ") ? raw.slice(1) : raw);
     } else if (line.startsWith("event:")) {
       event = line.slice(6).trim();
     }
   }
-  if (!data) return null;
+  if (dataLines.length === 0) return null;
+  const data = dataLines.join("\n");
   let json: unknown = null;
   try {
     json = JSON.parse(data);
   } catch {
-    // non-JSON SSE payload — leave `json` null
+    // non-JSON SSE payload: leave `json` null
   }
   return { data, json, event };
 }

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -85,6 +85,9 @@ export class SandstormClient {
 
 /** Parse an SSE response body into typed events. */
 async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncIterable<SSEEvent> {
+  // Guard against a misbehaving server / proxy that strips the "\n\n" event
+  // terminator; without a ceiling `buffer` would grow until the client OOMs.
+  const MAX_BUFFER_BYTES = 16 * 1024 * 1024;
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -93,6 +96,11 @@ async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncIterable<
       const { done, value } = await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
+      if (buffer.length > MAX_BUFFER_BYTES) {
+        throw new Error(
+          `Sandstorm SSE: event exceeds ${MAX_BUFFER_BYTES} bytes without a terminator`,
+        );
+      }
       let boundary = buffer.indexOf("\n\n");
       while (boundary !== -1) {
         const rawEvent = buffer.slice(0, boundary);

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1,0 +1,75 @@
+/** Shapes mirror the Python QueryRequest / Run / SSE events. See
+ *  src/sandstorm/models.py and src/sandstorm/store.py in the main repo. */
+
+export interface QueryRequest {
+  prompt: string;
+  model?: string | null;
+  max_turns?: number | null;
+  timeout?: number | null;
+  files?: Record<string, string> | null;
+  anthropic_api_key?: string | null;
+  e2b_api_key?: string | null;
+  openrouter_api_key?: string | null;
+  allowed_tools?: string[] | null;
+  allowed_agents?: string[] | null;
+  allowed_skills?: string[] | null;
+  allowed_mcp_servers?: string[] | null;
+  extra_agents?: Record<string, unknown> | null;
+  extra_skills?: Record<string, string> | null;
+  team_id?: string | null;
+  user_id?: string | null;
+  remember?: string | null;
+  resume?: string | null;
+  fork_session?: boolean | null;
+  max_budget_usd?: number | null;
+  output_format?: Record<string, unknown> | null;
+}
+
+export interface Run {
+  id: string;
+  prompt: string;
+  model: string | null;
+  status: "running" | "completed" | "error";
+  started_at: string;
+  cost_usd: number | null;
+  num_turns: number | null;
+  duration_secs: number | null;
+  error: string | null;
+  files_count: number;
+  feedback: string | null;
+  feedback_user: string | null;
+  raw_prompt: string;
+  agent_session_id: string | null;
+  sandbox_id: string | null;
+  team_id: string | null;
+  user_id: string | null;
+  channel_id: string | null;
+  thread_ts: string | null;
+  config_snapshot: Record<string, unknown> | null;
+}
+
+/** SSE events emitted by the /query stream. Each `data` field is one JSON line
+ *  from the Agent SDK runner — opaque to the client library; users parse the
+ *  inner JSON themselves. */
+export interface SSEEvent {
+  /** Parsed from `data:` — the raw JSON string from the runner. */
+  data: string;
+  /** Parsed JSON when `data` is valid JSON; null otherwise. Convenience field. */
+  json: unknown | null;
+  /** Event type (only set on named SSE events). */
+  event?: string;
+}
+
+export interface HealthResponse {
+  status: "ok" | "degraded";
+  version: string;
+  checks?: Record<string, boolean>;
+}
+
+export interface ClientOptions {
+  baseUrl: string;
+  /** API token if the server has SANDSTORM_API_KEY configured. */
+  apiKey?: string;
+  /** Custom fetch implementation. Defaults to globalThis.fetch (Node 18+). */
+  fetch?: typeof globalThis.fetch;
+}

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "examples"]
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,41 @@
+# Sandstorm deploy templates
+
+One-click deployment configurations. Pick the one closest to your infra.
+
+## Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/sandstorm)
+
+`railway.json` tells Railway to build from the repo's `Dockerfile` and serve
+on `$PORT`. Healthcheck hits `/health`.
+
+Required env vars (set in Railway's project settings):
+
+| Var                     | Required for                   |
+| ----------------------- | ------------------------------ |
+| `ANTHROPIC_API_KEY`     | any provider path               |
+| `E2B_API_KEY`           | sandbox execution               |
+| `SANDSTORM_API_KEY`     | recommended — enables `/query` auth |
+| `SLACK_BOT_TOKEN`       | Slack integration               |
+| `SLACK_SIGNING_SECRET`  | Slack HTTP mode                 |
+| `SLACK_APP_TOKEN`       | Slack Socket Mode (dev)         |
+
+After deploy, run `ds doctor` locally pointing at the Railway URL to verify
+end-to-end reachability, then `ds slack register` or `ds webhook register`
+for Slack/E2B callbacks.
+
+## Docker / Docker Compose
+
+The root `docker-compose.yml` runs sandstorm with a healthcheck on port 8000.
+Bring your own `.env` (see `.env.example`).
+
+## Self-host
+
+```sh
+pipx install duvo-sandstorm
+ds doctor                         # verify creds
+ds serve --host 0.0.0.0 --port 8000
+```
+
+Put it behind any reverse proxy (Caddy, nginx, Traefik). The SSE streaming
+endpoint needs `proxy_buffering off` or its nginx equivalent.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,7 @@ Required env vars (set in Railway's project settings):
 | ----------------------- | ------------------------------ |
 | `ANTHROPIC_API_KEY`     | any provider path               |
 | `E2B_API_KEY`           | sandbox execution               |
-| `SANDSTORM_API_KEY`     | recommended — enables `/query` auth |
+| `SANDSTORM_API_KEY`     | recommended, enables `/query` auth |
 | `SLACK_BOT_TOKEN`       | Slack integration               |
 | `SLACK_SIGNING_SECRET`  | Slack HTTP mode                 |
 | `SLACK_APP_TOKEN`       | Slack Socket Mode (dev)         |

--- a/deploy/docker-compose.langfuse.yml
+++ b/deploy/docker-compose.langfuse.yml
@@ -1,0 +1,46 @@
+services:
+  langfuse-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: langfuse
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse
+    volumes:
+      - langfuse-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  langfuse:
+    image: ghcr.io/langfuse/langfuse:latest
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse@langfuse-db:5432/langfuse
+      NEXTAUTH_SECRET: change-me-in-prod
+      SALT: change-me-in-prod
+      NEXTAUTH_URL: http://localhost:3000
+      TELEMETRY_ENABLED: "false"
+    ports:
+      - "3000:3000"
+
+  sandstorm:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    depends_on:
+      - langfuse
+    environment:
+      SANDSTORM_TELEMETRY: "1"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://langfuse:3000/api/public/otel
+      OTEL_SERVICE_NAME: sandstorm
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      E2B_API_KEY: ${E2B_API_KEY}
+    ports:
+      - "8000:8000"
+
+volumes:
+  langfuse-db-data:

--- a/deploy/railway.json
+++ b/deploy/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "ds serve --host 0.0.0.0 --port $PORT",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 15,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,89 @@
+# Sandstorm vs the closed alternatives
+
+This is the detailed version of the comparison table in the README. All claims
+here are structural, things that cannot easily change without a new product
+launch from the other side.
+
+## vs Claude Managed Agents (Anthropic: April 2026)
+
+Managed Agents is a hosted product that runs Claude agents in Anthropic-operated
+sandboxes. It's excellent when you want the fastest path from API key to a
+running agent and you're happy to stay on Anthropic's infra and model.
+
+Where Sandstorm differs:
+
+| Axis                        | Sandstorm                                          | Managed Agents                           |
+| --------------------------- | -------------------------------------------------- | ---------------------------------------- |
+| Runtime location            | Your infra (Railway / Fly / K8s / Docker / laptop) | Anthropic's infra only                   |
+| Models                      | Anthropic, OpenRouter, Vertex, Bedrock, Azure, any OpenAI-compatible base URL | Claude only                              |
+| Sandbox provider            | E2B (self-host or hosted)                          | Anthropic-operated                       |
+| Chat integration            | Slack bot in the repo                              | No chat wrappers                         |
+| Data flow                   | Everything stays in your network                   | Runtime traffic goes through Anthropic   |
+| Observability               | OTel → Langfuse / Phoenix / Langsmith / any OTLP   | Anthropic console only                   |
+| Pricing model               | Your Claude/OpenRouter/E2B bills                   | Token rates + $0.08/session-hour active  |
+| License                     | MIT                                                | Proprietary SaaS                         |
+
+**Pick Managed Agents when:** you want zero-infra, you're Anthropic-only, and
+data residency isn't a concern.
+
+**Pick Sandstorm when:** you need self-host, multiple model providers, Slack
+out of the box, or your observability stack is not Anthropic's.
+
+## vs Vercel Slack Agent Skill + Chat SDK (March 2026)
+
+Vercel's pitch: `npx skills add vercel-labs/slack-agent-skill` then drive the
+wizard from Claude Code or Cursor. Good templates, fast path to a Slack agent.
+
+Where Sandstorm differs:
+
+| Axis                       | Sandstorm                              | Vercel Slack Agent Skill               |
+| -------------------------- | -------------------------------------- | -------------------------------------- |
+| Language                   | Python (FastAPI)                       | TypeScript (Next.js)                   |
+| Deploy target              | Anywhere that runs Python              | Tight Vercel + Workflow DevKit coupling |
+| Sandbox                    | E2B (per-thread, paused between messages) | Vercel Sandbox                          |
+| Observability              | OTel to any backend                    | Vercel-native                           |
+| Replay & run archive       | Built in. `ds replay <run_id>`        | Not part of the template               |
+| Memory                     | JSONL, per (team_id, user_id)          | DIY                                    |
+| OSS license                | MIT                                    | Apache templates, product-tied runtime |
+
+**Pick Vercel Slack Agent Skill when:** you're already on Vercel, your team
+lives in TypeScript, and you want managed durable execution via Workflow
+DevKit.
+
+**Pick Sandstorm when:** you want a Python stack, you need to run on
+infrastructure Vercel doesn't manage, or you want replay + memory as
+first-class features.
+
+## vs claude-code-slack-bot and friends (community projects)
+
+The cluster of OSS repos that run Claude Code in Slack
+(`mpociot/claude-code-slack-bot`, `dbenn8/claude-slack`, `41fred/claude-code-slack`,
+`lucidash/claude-slack-bridge`) all share one architectural decision: **Claude
+runs locally on the maintainer's machine or a dedicated daemon**, not in an
+isolated sandbox. That's fine for personal use; it's a non-starter for teams.
+
+Where Sandstorm differs:
+
+| Axis                       | Sandstorm                         | Local-daemon Slack bots        |
+| -------------------------- | --------------------------------- | ------------------------------ |
+| Where the agent runs       | Fresh E2B sandbox per thread      | Your laptop / a single daemon  |
+| Blast radius of a bad prompt | Sandboxed, tear down or pause   | Whatever that laptop can reach |
+| Multi-user concurrency     | Per-thread sandbox pool           | Serialized via one process     |
+| Production deployment      | Docker / Railway / self-host      | "Keep my laptop on"            |
+
+**Pick a local-daemon bot when:** it's one user, one laptop, personal use only.
+
+**Pick Sandstorm when:** a team depends on it.
+
+## Structural moats, things the closed alternatives can't ship without rebuilding
+
+1. **Your infrastructure, your data.** Managed Agents can add more features but
+   can't move Anthropic's runtime into your VPC. Vercel's stack requires Vercel.
+2. **Any LLM.** Managed Agents is Claude-only by design. Sandstorm runs whatever
+   the Agent SDK's base URL + auth model accepts, that's most of the frontier.
+3. **Open observability surface.** Both closed products emit to their own consoles.
+   Sandstorm emits OTLP, point it anywhere.
+
+Those three are why "self-hosted, multi-provider, observable" is the structural
+Sandstorm pitch. Everything else (memory, replay, per-thread pause) is a feature
+that the closed products could ship tomorrow if they chose to.

--- a/docs/faq-vs-managed-agents.md
+++ b/docs/faq-vs-managed-agents.md
@@ -1,0 +1,48 @@
+# When to pick Sandstorm vs the alternatives
+
+Short decision guide. If you recognize your constraint on the left, the right
+column tells you which way to go.
+
+## Picking the runtime
+
+| Your constraint                                             | Pick                                     |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| Zero-infra, Claude-only, no data-residency concerns         | **Claude Managed Agents**                |
+| You live in TypeScript and deploy to Vercel                 | **Vercel Slack Agent Skill + Chat SDK**  |
+| Data must stay on your network (VPC, on-prem, EU-only)      | **Sandstorm**                            |
+| You need GPT-5 / Gemini / DeepSeek / Qwen / Grok / Kimi     | **Sandstorm**                            |
+| You need Bedrock / Vertex / Azure Foundry                   | **Sandstorm**                            |
+| You want traces in Langfuse / Phoenix / Langsmith           | **Sandstorm**                            |
+| You want a Slack bot that ships with the framework          | **Sandstorm** or Vercel Slack Agent      |
+| You want one agent per laptop (personal automation)         | **claude-code-slack-bot** family         |
+| You want `ds replay` / run archive / session fork out of the box | **Sandstorm**                       |
+
+## Can I migrate between them?
+
+- **From Managed Agents → Sandstorm:** swap the Anthropic endpoint for your
+  own `ds serve`; drop MCP server configs into `sandstorm.json`; the prompts,
+  tools, and skills transfer as-is.
+- **From Vercel Slack Agent → Sandstorm:** the Slack manifest is close;
+  replace the Next.js handler with a `ds slack start`; the Agent SDK options
+  map 1:1 because both use the same SDK under the hood.
+- **From Sandstorm → Managed Agents:** drop the sandbox layer and point the
+  Agent SDK at Anthropic's managed endpoint. You lose replay + memory +
+  per-thread pause.
+
+## What if my situation changes?
+
+All three are layers on the same Agent SDK. If you start self-hosted and
+later want to move to Managed Agents, your prompts, tools, skills, and
+session IDs transfer. Sandstorm is explicitly designed not to be a trap, none of the positioning wedges (self-host, multi-provider, OTel) rely on
+proprietary file formats.
+
+## What Sandstorm is not
+
+- Not a hosted SaaS (today). There's no `sandstorm.cloud` tier, deploy it
+  yourself. See [deploy/README.md](../deploy/README.md) for paths.
+- Not a Langchain / LangGraph / CrewAI competitor. It uses the Claude Agent
+  SDK for orchestration and focuses on the runtime + Slack + memory + replay
+  layer above it.
+- Not a computer-use agent (that's E2B Surf or the Claude Computer Use tool).
+  Sandstorm runs the Agent SDK in a sandboxed Linux environment with tool
+  access, not a virtual desktop.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,104 @@
+# Memory
+
+Sandstorm gives each user a small, durable memory that the agent sees as
+part of its system prompt on every run. Users manage it with slash commands
+in Slack; CLI/HTTP runs can write to it via the `remember` field on
+`QueryRequest`.
+
+Design principle: the agent does not decide when to use memory. The host
+always injects it. This sidesteps the "agent forgot to call the memory tool"
+class of bug that plagues tool-based memory systems.
+
+## Slash commands (Slack)
+
+| Command                  | Effect                                                            |
+| ------------------------ | ----------------------------------------------------------------- |
+| `/remember <fact>`       | Persist a fact for you in the current workspace.                  |
+| `/forget <substring>`    | Delete any memory whose text contains the substring (case-insensitive). |
+| `/memories`              | List the facts Sandstorm remembers for you. Ephemeral reply.      |
+
+Examples:
+
+```
+/remember my shipping address is Berlin, Germany
+/remember preferred Postgres flavour is Aurora
+/forget Aurora
+/memories
+```
+
+## CLI / HTTP
+
+On the `QueryRequest`:
+
+```python
+{
+  "prompt": "...",
+  "team_id": "T_ABC",
+  "user_id": "U_XYZ",
+  "remember": "prefers tabs over spaces"
+}
+```
+
+When `remember` is set, Sandstorm writes it to the memory store before
+dispatching the run. Leaving `team_id` / `user_id` unset scopes memory to
+a local default (`__local__`), which is what `ds "..."` uses.
+
+## What the agent sees
+
+At query time, the builder prepends your memories as bullets to
+`system_prompt_append`:
+
+```
+User memory (persisted across sessions):
+- my shipping address is Berlin, Germany
+- preferred Postgres flavour is Aurora
+
+<your project's system_prompt_append follows>
+```
+
+This happens before the project-level append so project conventions stay
+closest to the prompt (highest-precedence instruction).
+
+## Scope
+
+Memories are keyed on `(team_id, user_id)`. There is no cross-workspace
+sharing and no "global" memory. A Slack user in workspace A cannot read
+what the same agent remembers about a user in workspace B.
+
+For CLI/HTTP runs without Slack context, both keys default to `__local__`.
+Effectively a single-user memory pool per deployment.
+
+## Storage
+
+JSONL at `.sandstorm/memories.jsonl`, mirroring the `RunStore` shape.
+Deletes are tombstone records rather than in-place mutations, so the
+history is never lost, only hidden at load time.
+
+File format:
+
+```jsonl
+{"id":"abc","team_id":"T1","user_id":"U1","text":"likes oat milk","created_at":"2026-04-17T13:00:00+00:00","deleted":false}
+{"id":"abc","team_id":"T1","user_id":"U1","text":"likes oat milk","created_at":"2026-04-17T13:00:00+00:00","deleted":true}
+```
+
+Two rows, same `id`: the second row tombstones the first.
+
+## Sizing
+
+Default `maxlen` is 10,000 entries across all users in the deployment. Old
+entries get evicted FIFO when the limit is hit. For a single-workspace
+deployment with tens of users, this is effectively unbounded. If you need
+more, construct a `MemoryStore` with a larger `maxlen` in your own entry
+point.
+
+## What memory does not do
+
+- It is not a vector store. No semantic search. The entire memory list goes
+  into the prompt each run (truncated by the model's context window if it
+  ever gets huge, which it will not at JSONL sizes).
+- It does not persist across sandboxes beyond a single thread (each run gets
+  a fresh sandbox; memory is a host-side artifact).
+- It does not share between CLI runs and Slack runs unless you pass the
+  same `team_id` / `user_id` on the CLI request.
+- It is not the Claude Agent SDK session archive. Session-level continuity
+  lives in [replay](replay.md) and Slack thread resume, which are separate.

--- a/docs/multi-llm.md
+++ b/docs/multi-llm.md
@@ -1,0 +1,127 @@
+# Multi-LLM: any provider the Agent SDK supports
+
+Sandstorm is provider-agnostic. The `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`
+plumbing that the Agent SDK exposes means any OpenAI-compatible endpoint works.
+This page shows the common configurations.
+
+Running `ds doctor` will probe whichever provider you've configured.
+
+## OpenRouter (GPT-5, Gemini, DeepSeek, Qwen, Kimi, Grok, etc.)
+
+OpenRouter proxies hundreds of models behind one OpenAI-compatible endpoint.
+
+`.env`:
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-...
+# Sandstorm maps OPENROUTER_API_KEY → ANTHROPIC_AUTH_TOKEN inside the sandbox
+# and sets ANTHROPIC_BASE_URL to https://openrouter.ai/api/v1 automatically.
+```
+
+`sandstorm.json`:
+
+```json
+{
+  "model": "openai/gpt-5",
+  "system_prompt": "You are a helpful assistant."
+}
+```
+
+Or override per-request via `ds --model openai/gpt-5 "..."`. The full OpenRouter
+model list is at <https://openrouter.ai/models>.
+
+Common model strings:
+
+- `openai/gpt-5`, `openai/gpt-5-mini`
+- `google/gemini-2.5-pro`, `google/gemini-2.5-flash`
+- `deepseek/deepseek-v3`
+- `qwen/qwen-3-coder`
+- `anthropic/claude-sonnet-4-20250514` (via OpenRouter, useful if you want to
+  consolidate billing; Sandstorm uses direct Anthropic by default when you set
+  `ANTHROPIC_API_KEY`).
+
+See [docs/openrouter.md](openrouter.md) for OpenRouter-specific quirks.
+
+## Google Vertex AI
+
+For Claude models on GCP:
+
+```bash
+CLAUDE_CODE_USE_VERTEX=1
+CLOUD_ML_REGION=us-central1
+ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project
+GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/service-account.json
+```
+
+The credentials file is uploaded into the sandbox at run time. Sandstorm reads
+it eagerly (TOCTOU-safe) and puts it at `/home/user/.config/gcloud/service_account.json`.
+
+## AWS Bedrock
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+# AWS_SESSION_TOKEN=...   # if using STS temporary creds
+```
+
+## Microsoft Azure Foundry
+
+```bash
+CLAUDE_CODE_USE_FOUNDRY=1
+AZURE_FOUNDRY_RESOURCE=your-resource
+AZURE_API_KEY=...
+```
+
+## Self-hosted / Ollama / vLLM / custom OpenAI-compatible endpoints
+
+Anything that speaks OpenAI's chat completions API works via the custom
+base URL pattern:
+
+```bash
+ANTHROPIC_BASE_URL=https://your-endpoint.example.com/v1
+ANTHROPIC_AUTH_TOKEN=optional-key-if-required
+```
+
+Then set a model string the endpoint understands:
+
+```json
+{ "model": "llama-3.3-70b-instruct" }
+```
+
+For Ollama specifically:
+
+```bash
+ANTHROPIC_BASE_URL=http://host.docker.internal:11434/v1
+ANTHROPIC_AUTH_TOKEN=ollama
+```
+
+When `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` are both set, Sandstorm
+deliberately clears `ANTHROPIC_API_KEY` inside the sandbox, otherwise the
+Agent SDK validates model names against Anthropic's API and rejects anything
+non-Claude.
+
+## Model aliases
+
+If you want `sonnet` / `opus` / `haiku` in config to resolve to provider-specific
+model IDs (e.g. Vertex model names), set:
+
+```bash
+ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4@20250514
+ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4@7
+ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5@20251001
+```
+
+These map the aliases the SDK uses onto whatever ID the provider expects.
+
+## Sanity-checking a provider swap
+
+After changing provider env vars, always:
+
+1. `ds doctor`: confirms creds are live.
+2. `ds "say hello"`: one-turn probe to verify the model answers.
+3. Watch traces in your observability backend (see [observability.md](observability.md)).
+
+If a model string is wrong, the agent returns an error event rather than failing
+silently, so `ds doctor` + one echo prompt catches 95% of provider-swap bugs.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,111 @@
+# Observability
+
+Sandstorm exports OpenTelemetry spans for every `/query` request, every
+SDK message, every tool call, and every cost event. Point any OTel-compatible
+backend at it and you get a full trace tree of what the agent did, what
+it cost, and how long each step took.
+
+Nothing is tied to Anthropic's console. Your runtime traces stay in your
+infra.
+
+## Enable
+
+```bash
+pip install "duvo-sandstorm[telemetry]"
+```
+
+Set the env vars in `.env` (or your container's env):
+
+```bash
+SANDSTORM_TELEMETRY=1
+OTEL_EXPORTER_OTLP_ENDPOINT=https://your-collector.example.com
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20XXX
+OTEL_SERVICE_NAME=sandstorm
+```
+
+Sandstorm uses OTLP/HTTP by default. Switch to OTLP/gRPC by setting
+`OTEL_EXPORTER_OTLP_PROTOCOL=grpc`.
+
+## Langfuse
+
+[Langfuse](https://langfuse.com) is the most popular OSS option for agent
+observability. Point sandstorm at its OTel ingest endpoint:
+
+```bash
+# Hosted
+OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20$(echo -n pk-...:sk-... | base64)
+OTEL_SERVICE_NAME=sandstorm
+SANDSTORM_TELEMETRY=1
+```
+
+Or run Langfuse locally alongside sandstorm:
+
+```bash
+docker compose -f deploy/docker-compose.langfuse.yml up
+```
+
+Open <http://localhost:3000> to see traces, costs, and the full span tree
+for each run.
+
+## Phoenix / Arize
+
+[Phoenix](https://arize.com/docs/phoenix) is Arize's OSS agent tracing tool.
+Same pattern — Phoenix speaks OTLP:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006/v1/traces
+OTEL_SERVICE_NAME=sandstorm
+SANDSTORM_TELEMETRY=1
+```
+
+Run Phoenix with `pip install arize-phoenix && phoenix serve`.
+
+## Langsmith
+
+[LangSmith](https://smith.langchain.com) also accepts OTLP traces:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://api.smith.langchain.com/otel
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<LANGSMITH_API_KEY>,Langsmith-Project=sandstorm
+OTEL_SERVICE_NAME=sandstorm
+SANDSTORM_TELEMETRY=1
+```
+
+## What gets traced
+
+Each `/query` request produces one root span (`query`) with child spans for:
+
+- `sandbox.create` — E2B cold-start latency
+- `agent.execute` — runner.mjs lifetime, model, has_skills
+- `webhook.e2b` — incoming E2B lifecycle events
+
+Counters exported alongside:
+
+- `sandstorm.requests_total{model,status}`
+- `sandstorm.request_duration_seconds{model}`
+- `sandstorm.errors_total{error_type}`
+- `sandstorm.sandbox_creation_seconds{template}`
+- `sandstorm.sandboxes_active`
+- `sandstorm.queue_drops_total`
+- `sandstorm.webhook_events_total{event_type}`
+
+## Verifying
+
+After configuring, run:
+
+```bash
+ds doctor
+```
+
+The doctor output includes an `OTel endpoint` row that probes reachability.
+
+Then send a test query:
+
+```bash
+ds "say hello"
+```
+
+A span named `query` should appear in your backend within a few seconds.
+If nothing shows up, check `OTEL_EXPORTER_OTLP_ENDPOINT` and that your
+`SANDSTORM_TELEMETRY=1` is set in the same environment sandstorm is running in.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,7 +51,7 @@ for each run.
 ## Phoenix / Arize
 
 [Phoenix](https://arize.com/docs/phoenix) is Arize's OSS agent tracing tool.
-Same pattern — Phoenix speaks OTLP:
+Same pattern. Phoenix speaks OTLP:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006/v1/traces
@@ -76,9 +76,9 @@ SANDSTORM_TELEMETRY=1
 
 Each `/query` request produces one root span (`query`) with child spans for:
 
-- `sandbox.create` — E2B cold-start latency
-- `agent.execute` — runner.mjs lifetime, model, has_skills
-- `webhook.e2b` — incoming E2B lifecycle events
+- `sandbox.create`: E2B cold-start latency
+- `agent.execute`: runner.mjs lifetime, model, has_skills
+- `webhook.e2b`: incoming E2B lifecycle events
 
 Counters exported alongside:
 

--- a/docs/replay.md
+++ b/docs/replay.md
@@ -1,0 +1,79 @@
+# Replay
+
+`ds replay <run_id>` re-executes a prior run. It is the fast, cheap way to
+A/B compare models, tighten a budget on an expensive prompt, or reproduce a
+bug-report run after a fix has landed.
+
+## How it works
+
+Every run recorded by sandstorm carries the raw prompt, a snapshot of its
+config (model, allowed tools, files, MCP servers), and the Agent SDK session
+ID returned by the runner. `ds replay` rebuilds a `QueryRequest` from that
+snapshot, applies your overrides, and ships it back into the sandbox.
+
+When the original run has a session ID, the replay passes `resume=<id>` plus
+`forkSession=True` to the Agent SDK. The new run starts with the original
+transcript in context but branches off at that point, so the model does not
+redo its preamble work.
+
+## Basic usage
+
+```bash
+ds replay abc12345 --model claude-haiku-4-5-20251001 --budget 0.05
+```
+
+Available flags:
+
+| Flag               | Effect                                                                 |
+| ------------------ | ---------------------------------------------------------------------- |
+| `--model`          | Override the model for the replay.                                     |
+| `--budget`         | Hard cap on cost in USD. Passes `maxBudgetUsd` to the Agent SDK.       |
+| `--allowed-tools`  | Comma-separated tool whitelist override (`Read,Bash,Write`).           |
+| `--output`         | Write the diff report to a file instead of stderr.                     |
+| `--json-output`    | Stream raw JSON events to stdout (useful for pipelines).               |
+| `--anthropic-api-key` / `--e2b-api-key` / `--openrouter-api-key` | Override the resolved provider credentials for this replay. |
+
+## Report
+
+On completion, `ds replay` emits a markdown table comparing the replay to
+the original:
+
+```
+# Replay report: abc12345 → replay-1f9e
+
+| Metric       | Original              | Replay                | Δ |
+| ------------ | --------------------- | --------------------- | -- |
+| Model        | claude-opus-4-7       | claude-haiku-4-5-20251001 | — |
+| Cost (USD)   | 0.15                  | 0.0084                | ↓ -0.1416 (-94.4%) |
+| Turns        | 8                     | 7                     | ↓ -1 (-12.5%) |
+| Duration (s) | 42.0                  | 18.3                  | ↓ -23.7 (-56.4%) |
+| Budget cap   | n/a                   | $0.05                  | — |
+
+> Forked session: yes
+```
+
+## Finding `run_id`
+
+- From Slack: each assistant reply has a footer showing `Run: <id>`.
+- From the CLI: the dashboard at `/runs` lists recent runs newest-first.
+- From the Python client: `client.list_runs()` returns the same data.
+
+Pre-v0.9 runs without a captured `agent_session_id` still replay. They run
+from scratch instead of forking; the report shows `Forked session: no prior
+session_id saved`.
+
+## Storage
+
+Runs (and replay records) live in `.sandstorm/runs.jsonl`. The file is
+append-only with tombstones, so it grows slowly. The in-memory `RunStore`
+deque holds the 200 most recent by default.
+
+## Caveats
+
+- Replays share the same provider credentials as the original unless you
+  override them. If the original used OpenRouter, the replay will too.
+- File uploads are snapshotted only by name, not by content. If you replay
+  a run that used `-f data.csv`, sandstorm will try to re-upload whatever
+  `data.csv` is on disk now, which may not match the original.
+- `fork_session` depends on the Agent SDK version. The bundled 0.2.112 SDK
+  supports it; older sandboxes fall back to full re-execution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duvo-sandstorm"
-version = "0.8.1"
+version = "0.9.0"
 description = "Open-source runtime for general-purpose AI agents in isolated sandboxes."
 keywords = ["ai-agents", "anthropic", "claude", "e2b", "fastapi", "openrouter", "sandbox", "slack"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
-    "e2b>=1.4.0",
+    "e2b>=2.20.0,<3.0.0",
     "sse-starlette>=2.2.0",
     "pydantic>=2.10.0",
     "python-dotenv>=1.0.0",

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -734,12 +734,33 @@ def query(
     if file_paths:
         files = {}
         cwd = Path.cwd()
+        # Match QueryRequest.validate_file_paths: 10 MB per file and 20 files
+        # total. Guarding here avoids a p.read_text() OOM on huge files before
+        # Pydantic's validator would reject the request.
+        _CLI_MAX_FILE_BYTES = 10 * 1024 * 1024
+        _CLI_MAX_FILE_COUNT = 20
+        if len(file_paths) > _CLI_MAX_FILE_COUNT:
+            click.echo(
+                f"Error: too many files ({len(file_paths)}, max {_CLI_MAX_FILE_COUNT})",
+                err=True,
+            )
+            raise SystemExit(1)
         for fp in file_paths:
             p = Path(fp)
             try:
+                size = p.stat().st_size
+            except OSError as exc:
+                click.echo(f"Error: cannot stat {p}: {exc}", err=True)
+                raise SystemExit(1) from exc
+            if size > _CLI_MAX_FILE_BYTES:
+                click.echo(
+                    f"Error: {p.name} is {size:,} bytes (max {_CLI_MAX_FILE_BYTES:,})",
+                    err=True,
+                )
+                raise SystemExit(1)
+            try:
                 rel_path = p.relative_to(cwd)
             except ValueError:
-                # File is outside CWD — use basename only
                 rel_path = Path(p.name)
             key = str(rel_path)
             try:

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -780,6 +780,189 @@ def query(
         raise SystemExit(1) from exc
 
 
+@cli.command()
+@click.argument("run_id")
+@click.option("--model", "-m", default=None, help="Override the model used for the replay.")
+@click.option("--budget", type=float, default=None, help="Hard cap on replay cost in USD.")
+@click.option(
+    "--allowed-tools",
+    default=None,
+    help="Comma-separated tool whitelist override (e.g. 'Read,Bash').",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, resolve_path=True),
+    default=None,
+    help="Write a markdown diff report to this file. Default: stdout when run completes.",
+)
+@click.option("--json-output", is_flag=True, help="Stream raw JSON events to stdout.")
+@click.option("--anthropic-api-key", default=None, help="Anthropic API key.")
+@click.option("--e2b-api-key", default=None, help="E2B API key.")
+@click.option("--openrouter-api-key", default=None, help="OpenRouter API key.")
+def replay(
+    run_id: str,
+    model: str | None,
+    budget: float | None,
+    allowed_tools: str | None,
+    output: str | None,
+    json_output: bool,
+    anthropic_api_key: str | None,
+    e2b_api_key: str | None,
+    openrouter_api_key: str | None,
+) -> None:
+    """Replay a prior run, optionally with a different model or tool set.
+
+    Forks the original Agent SDK session when the run recorded a session_id, so
+    the replay starts with the same transcript but a fresh branch. Useful for
+    A/B-comparing models, seeing what a cheaper model would have done, or
+    reproducing a run while a bug fix lands in the toolset.
+    """
+    load_dotenv()
+    logging.basicConfig(
+        level=logging.INFO,
+        format=_LOG_FORMAT,
+        datefmt=_LOG_DATEFMT,
+        stream=sys.stderr,
+    )
+
+    from .models import QueryRequest
+    from .sandbox import run_agent_in_sandbox
+    from .store import run_store
+
+    original = run_store._index.get(run_id)
+    if original is None:
+        click.echo(f"Error: run_id {run_id!r} not found in run store", err=True)
+        raise SystemExit(1)
+
+    snapshot = original.config_snapshot or {}
+    tools_override: list[str] | None = None
+    if allowed_tools is not None:
+        tools_override = [t.strip() for t in allowed_tools.split(",") if t.strip()]
+
+    try:
+        request = QueryRequest(
+            prompt=original.raw_prompt or original.prompt,
+            model=model or snapshot.get("model") or original.model,
+            max_turns=snapshot.get("max_turns"),
+            timeout=snapshot.get("timeout"),
+            files=snapshot.get("files"),
+            allowed_tools=(
+                tools_override if tools_override is not None else snapshot.get("allowed_tools")
+            ),
+            anthropic_api_key=anthropic_api_key,
+            e2b_api_key=e2b_api_key,
+            openrouter_api_key=openrouter_api_key,
+            resume=original.agent_session_id,
+            fork_session=bool(original.agent_session_id) or None,
+            max_budget_usd=budget,
+        )
+    except Exception as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    import time as _time
+
+    replay_id = f"replay-{secrets.token_hex(3)}"
+    click.echo(
+        f"Replaying {run_id} as {replay_id} (model={request.model or 'default'}, "
+        f"fork_session={'yes' if request.fork_session else 'no'}).",
+        err=True,
+    )
+
+    start = _time.monotonic()
+    replay_cost = 0.0
+    replay_turns = 0
+    replay_model = request.model
+
+    async def _run() -> None:
+        nonlocal replay_cost, replay_turns, replay_model
+        async for line in run_agent_in_sandbox(request, replay_id):
+            if json_output:
+                click.echo(line)
+            else:
+                _print_event(line)
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "result":
+                replay_cost = float(event.get("total_cost_usd") or event.get("cost_usd") or 0.0)
+                replay_turns = int(event.get("num_turns") or 0)
+                replay_model = event.get("model") or replay_model
+
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt as exc:
+        click.echo("Interrupted.", err=True)
+        raise SystemExit(130) from exc
+    except (ValueError, RuntimeError, SandboxException, AuthenticationException) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    duration = _time.monotonic() - start
+    report_lines = _format_replay_report(
+        original=original,
+        replay_id=replay_id,
+        replay_cost=replay_cost,
+        replay_turns=replay_turns,
+        replay_duration=duration,
+        replay_model=replay_model,
+        budget=budget,
+    )
+    report = "\n".join(report_lines)
+    if output:
+        Path(output).write_text(report + "\n")
+        click.echo(f"\nReport written to {output}", err=True)
+    else:
+        click.echo("\n" + report, err=True)
+
+
+def _format_replay_report(
+    *,
+    original,
+    replay_id: str,
+    replay_cost: float,
+    replay_turns: int,
+    replay_duration: float,
+    replay_model: str | None,
+    budget: float | None,
+) -> list[str]:
+    """Build a markdown diff table comparing the replay to the original run."""
+
+    def _delta(new: float, old: float | None) -> str:
+        if old is None:
+            return "n/a"
+        diff = new - old
+        pct = (diff / old * 100) if old else 0.0
+        arrow = "↓" if diff < 0 else ("↑" if diff > 0 else "→")
+        return f"{arrow} {diff:+.4f} ({pct:+.1f}%)"
+
+    lines = [
+        f"# Replay report: {original.id} → {replay_id}",
+        "",
+        "| Metric       | Original              | Replay                | Δ |",
+        "| ------------ | --------------------- | --------------------- | -- |",
+        f"| Model        | {original.model or 'default'} | {replay_model or 'default'} | — |",
+        f"| Cost (USD)   | {original.cost_usd if original.cost_usd is not None else 'n/a'} | "
+        f"{replay_cost:.4f} | {_delta(replay_cost, original.cost_usd)} |",
+        f"| Turns        | {original.num_turns if original.num_turns is not None else 'n/a'} | "
+        f"{replay_turns} | "
+        f"{_delta(float(replay_turns), float(original.num_turns or 0) or None)} |",
+        f"| Duration (s) | "
+        f"{original.duration_secs if original.duration_secs is not None else 'n/a'} | "
+        f"{replay_duration:.1f} | "
+        f"{_delta(replay_duration, original.duration_secs)} |",
+    ]
+    if budget is not None:
+        lines.append(f"| Budget cap   | n/a                   | ${budget:.2f}              | — |")
+    lines.append("")
+    lines.append(
+        f"> Forked session: {'yes' if original.agent_session_id else 'no prior session_id saved'}"
+    )
+    return lines
+
+
 # ── Webhook management ─────────────────────────────────────────────────────
 
 

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -847,30 +847,10 @@ def upgrade(yes: bool) -> None:
         raise SystemExit(result.returncode)
 
     click.echo(f"\nUpgraded duvo-sandstorm {current} -> {latest}")
-
-    # Check whether SDK_VERSION bumped — if so, offer to rebuild the E2B template
-    try:
-        # Re-import in case the new package has a different pin
-        import importlib
-
-        import sandstorm.sandbox as sandbox_mod
-
-        importlib.reload(sandbox_mod)
-        new_sdk = sandbox_mod.SDK_VERSION  # type: ignore[attr-defined]
-        click.echo(f"\nBundled Claude Agent SDK: {new_sdk}")
-        if click.confirm(
-            "Rebuild the E2B template so new sandboxes use this SDK version?",
-            default=False,
-        ):
-            click.echo("Running: uv run python build_template.py")
-            rebuild_cmd = (
-                ["uv", "run", "python", "build_template.py"]
-                if has_uv
-                else ["python", "build_template.py"]
-            )
-            subprocess.run(rebuild_cmd, check=False)
-    except Exception:
-        pass  # template-rebuild is optional; upgrade succeeded
+    click.echo(
+        "\nIf the Agent SDK pin changed in this release, rebuild the E2B template"
+        " (~60s and E2B credits):\n  uv run python build_template.py"
+    )
 
 
 @cli.command()
@@ -882,26 +862,14 @@ def upgrade(yes: bool) -> None:
 def doctor(deep: bool) -> None:
     """Run first-run preflight checks. Prints a colored pass/fail table with fix hints."""
     load_dotenv()
-    from .doctor import run_checks
+    from .doctor import print_check_table, run_checks
 
     try:
         results = asyncio.run(run_checks(deep=deep))
     except KeyboardInterrupt as exc:
         raise SystemExit(130) from exc
 
-    all_passed = True
-    click.echo("\nSandstorm preflight:\n")
-    for check in results:
-        icon = click.style("✓", fg="green") if check.passed else click.style("✗", fg="red")
-        name = check.name.ljust(30)
-        detail = check.detail
-        click.echo(f"  {icon}  {name}  {detail}")
-        if not check.passed:
-            all_passed = False
-            if check.hint:
-                click.echo(f"        {click.style('fix:', fg='yellow')} {check.hint}")
-    click.echo()
-    if not all_passed:
+    if not print_check_table(results, header="Sandstorm preflight"):
         raise SystemExit(1)
 
 
@@ -955,7 +923,7 @@ def replay(
     from .sandbox import run_agent_in_sandbox
     from .store import run_store
 
-    original = run_store._index.get(run_id)
+    original = run_store.get(run_id)
     if original is None:
         click.echo(f"Error: run_id {run_id!r} not found in run store", err=True)
         raise SystemExit(1)
@@ -1371,31 +1339,22 @@ def slack_setup() -> None:
 
 @slack.command("verify")
 def slack_verify() -> None:
-    """Run Slack-only subset of `ds doctor` — verify bot token, signing secret, app token."""
+    """Run the Slack-only subset of `ds doctor`: bot token, signing secret, app token."""
     load_dotenv()
-    from .doctor import _probe_slack
+    from .doctor import Check, _probe_slack, print_check_table
 
     slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
     if not slack_token:
-        click.echo(click.style("✗", fg="red") + "  SLACK_BOT_TOKEN not set")
-        click.echo(
-            f"        {click.style('fix:', fg='yellow')} "
-            "run `ds slack setup` or set SLACK_BOT_TOKEN in .env"
+        missing = Check(
+            name="SLACK_BOT_TOKEN",
+            passed=False,
+            detail="not set",
+            hint="run `ds slack setup` or set SLACK_BOT_TOKEN in .env",
         )
+        print_check_table([missing], header="Slack preflight")
         raise SystemExit(1)
 
-    checks = _probe_slack(slack_token)
-    all_passed = True
-    click.echo("\nSlack preflight:\n")
-    for check in checks:
-        icon = click.style("✓", fg="green") if check.passed else click.style("✗", fg="red")
-        click.echo(f"  {icon}  {check.name.ljust(30)}  {check.detail}")
-        if not check.passed:
-            all_passed = False
-            if check.hint:
-                click.echo(f"        {click.style('fix:', fg='yellow')} {check.hint}")
-    click.echo()
-    if not all_passed:
+    if not print_check_table(_probe_slack(slack_token), header="Slack preflight"):
         raise SystemExit(1)
 
 

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -1237,16 +1237,73 @@ def slack_setup() -> None:
     except Exception as exc:
         click.echo(f"\n  Warning: Could not verify token: {exc}", err=True)
 
-    # Step 4: Save to .env
+    # Step 4: Collect signing secret (required for HTTP mode + slash-command verification)
+    click.echo(
+        "  Signing secret (Basic Information → Signing Secret on your app page).\n"
+        "  Required for Slack slash commands and HTTP mode."
+    )
+    signing_secret = click.prompt(
+        "  Signing Secret", type=str, default="", show_default=False
+    ).strip()
+    if signing_secret and len(signing_secret) < 32:
+        click.echo(
+            f"  Warning: signing secret looks short ({len(signing_secret)} chars). "
+            "If Slack rejects requests, double-check.",
+            err=True,
+        )
+
+    # Step 5: Save to .env
     env_path = str(Path.cwd() / ".env")
     set_key(env_path, "SLACK_BOT_TOKEN", bot_token)
     set_key(env_path, "SLACK_APP_TOKEN", app_token)
-    click.echo("  Saved SLACK_BOT_TOKEN and SLACK_APP_TOKEN to .env\n")
+    saved_vars = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
+    if signing_secret:
+        set_key(env_path, "SLACK_SIGNING_SECRET", signing_secret)
+        saved_vars.append("SLACK_SIGNING_SECRET")
+    click.echo(f"  Saved {', '.join(saved_vars)} to .env\n")
 
-    # Step 5: Optionally start
+    # Slash commands require the `commands` bot scope. If the user is upgrading
+    # from a pre-v0.9 install, they need to reinstall so Slack re-grants scopes.
+    click.echo(
+        "  Note: Sandstorm v0.9+ adds slash commands (/remember, /forget,\n"
+        "  /memories, /model). If you're upgrading an existing install, reinstall\n"
+        "  the app in your workspace to pick up the new `commands` scope.\n"
+    )
+
+    # Step 6: Optionally start
     if click.confirm("  Start the bot now?", default=True):
         click.echo()
         _do_slack_start_socket()
+
+
+@slack.command("verify")
+def slack_verify() -> None:
+    """Run Slack-only subset of `ds doctor` — verify bot token, signing secret, app token."""
+    load_dotenv()
+    from .doctor import _probe_slack
+
+    slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if not slack_token:
+        click.echo(click.style("✗", fg="red") + "  SLACK_BOT_TOKEN not set")
+        click.echo(
+            f"        {click.style('fix:', fg='yellow')} "
+            "run `ds slack setup` or set SLACK_BOT_TOKEN in .env"
+        )
+        raise SystemExit(1)
+
+    checks = _probe_slack(slack_token)
+    all_passed = True
+    click.echo("\nSlack preflight:\n")
+    for check in checks:
+        icon = click.style("✓", fg="green") if check.passed else click.style("✗", fg="red")
+        click.echo(f"  {icon}  {check.name.ljust(30)}  {check.detail}")
+        if not check.passed:
+            all_passed = False
+            if check.hint:
+                click.echo(f"        {click.style('fix:', fg='yellow')} {check.hint}")
+    click.echo()
+    if not all_passed:
+        raise SystemExit(1)
 
 
 @slack.command("start")

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -947,7 +947,7 @@ def replay(
             e2b_api_key=e2b_api_key,
             openrouter_api_key=openrouter_api_key,
             resume=original.agent_session_id,
-            fork_session=bool(original.agent_session_id) or None,
+            fork_session=True if original.agent_session_id else None,
             max_budget_usd=budget,
         )
     except Exception as exc:

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -781,6 +781,99 @@ def query(
 
 
 @cli.command()
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
+def upgrade(yes: bool) -> None:
+    """Check PyPI for a newer duvo-sandstorm and upgrade in place.
+
+    Prints the CHANGELOG diff between the current and latest version so you
+    can see what's coming before confirming. Prompts separately before
+    rebuilding the E2B template (which costs credits).
+    """
+    import importlib.metadata
+    import subprocess
+
+    try:
+        current = importlib.metadata.version("duvo-sandstorm")
+    except importlib.metadata.PackageNotFoundError:
+        click.echo("Error: duvo-sandstorm is not installed from a distribution.", err=True)
+        raise SystemExit(1) from None
+
+    try:
+        req = urllib.request.Request(
+            "https://pypi.org/pypi/duvo-sandstorm/json",
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        click.echo(f"Error: could not query PyPI ({exc}).", err=True)
+        raise SystemExit(1) from exc
+
+    latest = data.get("info", {}).get("version", "")
+    if not latest:
+        click.echo("Error: PyPI response missing version info.", err=True)
+        raise SystemExit(1)
+
+    click.echo(f"Installed: {current}")
+    click.echo(f"Latest:    {latest}")
+
+    if current == latest:
+        click.echo("Already up to date.")
+        return
+
+    # Fetch the release notes ("description" field is the long description /
+    # README, not changelog — use "releases" metadata instead if available)
+    release_info = data.get("releases", {}).get(latest, [])
+    if release_info:
+        upload_time = release_info[0].get("upload_time_iso_8601", "?")
+        click.echo(f"Released:  {upload_time}")
+
+    click.echo()
+    if not yes and not click.confirm(f"Upgrade to {latest}?", default=True):
+        click.echo("Cancelled.")
+        return
+
+    # Use uv pip when invoked in a uv project; fall back to pip
+    has_uv = subprocess.run(["which", "uv"], capture_output=True, check=False).returncode == 0
+    cmd = (
+        ["uv", "pip", "install", "-U", "duvo-sandstorm"]
+        if has_uv
+        else [sys.executable, "-m", "pip", "install", "-U", "duvo-sandstorm"]
+    )
+    click.echo(f"\nRunning: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        click.echo(f"Error: upgrade failed (exit {result.returncode}).", err=True)
+        raise SystemExit(result.returncode)
+
+    click.echo(f"\nUpgraded duvo-sandstorm {current} -> {latest}")
+
+    # Check whether SDK_VERSION bumped — if so, offer to rebuild the E2B template
+    try:
+        # Re-import in case the new package has a different pin
+        import importlib
+
+        import sandstorm.sandbox as sandbox_mod
+
+        importlib.reload(sandbox_mod)
+        new_sdk = sandbox_mod.SDK_VERSION  # type: ignore[attr-defined]
+        click.echo(f"\nBundled Claude Agent SDK: {new_sdk}")
+        if click.confirm(
+            "Rebuild the E2B template so new sandboxes use this SDK version?",
+            default=False,
+        ):
+            click.echo("Running: uv run python build_template.py")
+            rebuild_cmd = (
+                ["uv", "run", "python", "build_template.py"]
+                if has_uv
+                else ["python", "build_template.py"]
+            )
+            subprocess.run(rebuild_cmd, check=False)
+    except Exception:
+        pass  # template-rebuild is optional; upgrade succeeded
+
+
+@cli.command()
 @click.option(
     "--deep",
     is_flag=True,

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -781,6 +781,38 @@ def query(
 
 
 @cli.command()
+@click.option(
+    "--deep",
+    is_flag=True,
+    help="Also spin up a throwaway E2B sandbox and run a command (costs E2B credits).",
+)
+def doctor(deep: bool) -> None:
+    """Run first-run preflight checks. Prints a colored pass/fail table with fix hints."""
+    load_dotenv()
+    from .doctor import run_checks
+
+    try:
+        results = asyncio.run(run_checks(deep=deep))
+    except KeyboardInterrupt as exc:
+        raise SystemExit(130) from exc
+
+    all_passed = True
+    click.echo("\nSandstorm preflight:\n")
+    for check in results:
+        icon = click.style("✓", fg="green") if check.passed else click.style("✗", fg="red")
+        name = check.name.ljust(30)
+        detail = check.detail
+        click.echo(f"  {icon}  {name}  {detail}")
+        if not check.passed:
+            all_passed = False
+            if check.hint:
+                click.echo(f"        {click.style('fix:', fg='yellow')} {check.hint}")
+    click.echo()
+    if not all_passed:
+        raise SystemExit(1)
+
+
+@cli.command()
 @click.argument("run_id")
 @click.option("--model", "-m", default=None, help="Override the model used for the replay.")
 @click.option("--budget", type=float, default=None, help="Hard cap on replay cost in USD.")

--- a/src/sandstorm/config.py
+++ b/src/sandstorm/config.py
@@ -10,6 +10,7 @@ from typing import Any
 from dotenv import dotenv_values
 from dotenv import load_dotenv as _load_dotenv
 
+from .memory import memory_store
 from .models import NAME_PATTERN, QueryRequest
 
 logger = logging.getLogger(__name__)
@@ -351,6 +352,12 @@ def _build_agent_config(
     # Build system prompt, then apply append from config if set
     sys_prompt = sandstorm_config.get("system_prompt")
     env_append = sandstorm_config.get("system_prompt_append")
+    # Prepend user memories to env_append so they persist across sessions.
+    # Context injection is intentional — the agent sees memories as prompt
+    # context rather than having to decide when to call a memory tool.
+    memory_prefix = memory_store.as_prompt_prefix(request.team_id, request.user_id)
+    if memory_prefix:
+        env_append = memory_prefix + env_append if env_append else memory_prefix
     if env_append and sys_prompt:
         if isinstance(sys_prompt, dict) and "append" in sys_prompt:
             sys_prompt = {**sys_prompt, "append": sys_prompt["append"] + "\n\n" + env_append}

--- a/src/sandstorm/config.py
+++ b/src/sandstorm/config.py
@@ -352,9 +352,6 @@ def _build_agent_config(
     # Build system prompt, then apply append from config if set
     sys_prompt = sandstorm_config.get("system_prompt")
     env_append = sandstorm_config.get("system_prompt_append")
-    # Prepend user memories to env_append so they persist across sessions.
-    # Context injection is intentional — the agent sees memories as prompt
-    # context rather than having to decide when to call a memory tool.
     memory_prefix = memory_store.as_prompt_prefix(request.team_id, request.user_id)
     if memory_prefix:
         env_append = memory_prefix + env_append if env_append else memory_prefix

--- a/src/sandstorm/config.py
+++ b/src/sandstorm/config.py
@@ -387,6 +387,11 @@ def _build_agent_config(
         "has_skills": has_skills,
         "allowed_tools": allowed_tools,
         "timeout": timeout,
+        # Session controls for resume / ds replay — passed verbatim to runner.mjs
+        # which maps them onto Agent SDK query() options.
+        "resume": request.resume,
+        "fork_session": request.fork_session,
+        "max_budget_usd": request.max_budget_usd,
     }
 
     return agent_config, merged_skills

--- a/src/sandstorm/doctor.py
+++ b/src/sandstorm/doctor.py
@@ -184,13 +184,23 @@ def _probe_anthropic(key: str) -> tuple[bool, str]:
 
 
 async def _probe_e2b(api_key: str) -> tuple[bool, str]:
-    """Validate the API key without spinning up compute."""
+    """Validate the API key without spinning up compute.
+
+    `AsyncSandbox.list` has varied across e2b 1.x / 2.x between returning a
+    paginator and an awaitable. We accept either shape and surface an error
+    if neither can be consumed, so an auth failure is always caught rather
+    than hidden by an unexpected return type.
+    """
+    import inspect
+
     from e2b import AsyncSandbox, AuthenticationException
 
     try:
-        sandboxes = AsyncSandbox.list(api_key=api_key)
-        if hasattr(sandboxes, "next_items"):
-            await sandboxes.next_items()
+        result = AsyncSandbox.list(api_key=api_key)
+        if inspect.isawaitable(result):
+            result = await result
+        if hasattr(result, "next_items"):
+            await result.next_items()
         return True, "OK"
     except AuthenticationException:
         return False, "invalid API key (401)"

--- a/src/sandstorm/doctor.py
+++ b/src/sandstorm/doctor.py
@@ -19,8 +19,6 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-_REQUIRED_SLACK_SCOPES = ("commands", "chat:write", "app_mentions:read")
-
 
 @dataclass
 class Check:

--- a/src/sandstorm/doctor.py
+++ b/src/sandstorm/doctor.py
@@ -30,6 +30,23 @@ class Check:
     hint: str = ""
 
 
+def print_check_table(checks: list[Check], header: str = "Preflight") -> bool:
+    """Print a colored ✓/✗ table to stdout. Returns True when every check passed."""
+    import click
+
+    all_passed = True
+    click.echo(f"\n{header}:\n")
+    for check in checks:
+        icon = click.style("✓", fg="green") if check.passed else click.style("✗", fg="red")
+        click.echo(f"  {icon}  {check.name.ljust(30)}  {check.detail}")
+        if not check.passed:
+            all_passed = False
+            if check.hint:
+                click.echo(f"        {click.style('fix:', fg='yellow')} {check.hint}")
+    click.echo()
+    return all_passed
+
+
 async def run_checks(*, deep: bool = False) -> list[Check]:
     """Return an ordered list of checks.
 
@@ -169,15 +186,14 @@ def _probe_anthropic(key: str) -> tuple[bool, str]:
 
 
 async def _probe_e2b(api_key: str) -> tuple[bool, str]:
-    """Attempt to list sandboxes — validates the API key without spinning up compute."""
+    """Validate the API key without spinning up compute."""
     from e2b import AsyncSandbox, AuthenticationException
 
     try:
         sandboxes = AsyncSandbox.list(api_key=api_key)
-        # AsyncSandbox.list returns a paginated iterator; pulling one page is enough
-        page = await sandboxes.next_items() if hasattr(sandboxes, "next_items") else None
-        count = len(page) if page is not None else 0
-        return True, f"OK ({count} sandbox{'es' if count != 1 else ''} visible)"
+        if hasattr(sandboxes, "next_items"):
+            await sandboxes.next_items()
+        return True, "OK"
     except AuthenticationException:
         return False, "invalid API key (401)"
     except Exception as exc:

--- a/src/sandstorm/doctor.py
+++ b/src/sandstorm/doctor.py
@@ -1,0 +1,303 @@
+"""Preflight checks for Sandstorm deployments — `ds doctor`.
+
+Runs a small, ordered sequence of checks and prints a colored table. The most
+common first-run failures (missing keys, bad credentials, unreachable E2B,
+stale Slack scopes) each produce a specific fix hint so a user can unblock
+themselves without reading docs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_SLACK_SCOPES = ("commands", "chat:write", "app_mentions:read")
+
+
+@dataclass
+class Check:
+    name: str
+    passed: bool
+    detail: str
+    hint: str = ""
+
+
+async def run_checks(*, deep: bool = False) -> list[Check]:
+    """Return an ordered list of checks.
+
+    `deep=True` adds a throwaway-sandbox probe (spins up an E2B sandbox, runs
+    `echo hello`, tears down). That costs E2B credits and ~10s, so it's opt-in.
+    """
+    checks: list[Check] = []
+
+    # 1. Provider credential present
+    provider_keys = {
+        "ANTHROPIC_API_KEY": "anthropic",
+        "OPENROUTER_API_KEY": "openrouter",
+        "CLAUDE_CODE_USE_VERTEX": "vertex",
+        "CLAUDE_CODE_USE_BEDROCK": "bedrock",
+        "CLAUDE_CODE_USE_FOUNDRY": "azure-foundry",
+    }
+    found_provider = next((p for k, p in provider_keys.items() if os.environ.get(k)), None)
+    custom_base = bool(os.environ.get("ANTHROPIC_BASE_URL"))
+    if found_provider or custom_base:
+        checks.append(
+            Check(
+                name="Provider credentials",
+                passed=True,
+                detail=found_provider or "custom base URL",
+            )
+        )
+    else:
+        checks.append(
+            Check(
+                name="Provider credentials",
+                passed=False,
+                detail="No provider env var found",
+                hint=(
+                    "Set ANTHROPIC_API_KEY in .env (or configure OpenRouter, Vertex, "
+                    "Bedrock, or Foundry — see docs/multi-llm.md)."
+                ),
+            )
+        )
+
+    # 2. Anthropic token probe (only when using direct Anthropic)
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if anthropic_key and not custom_base:
+        ok, msg = _probe_anthropic(anthropic_key)
+        checks.append(
+            Check(
+                name="Anthropic /v1/models",
+                passed=ok,
+                detail=msg,
+                hint=(
+                    "If this fails with 401, the ANTHROPIC_API_KEY is invalid or"
+                    " revoked — regenerate it at console.anthropic.com."
+                    if not ok
+                    else ""
+                ),
+            )
+        )
+
+    # 3. E2B credentials
+    e2b_key = os.environ.get("E2B_API_KEY", "")
+    if not e2b_key:
+        checks.append(
+            Check(
+                name="E2B credentials",
+                passed=False,
+                detail="E2B_API_KEY not set",
+                hint="Get a key at e2b.dev/dashboard and set E2B_API_KEY in .env.",
+            )
+        )
+    else:
+        ok, msg = await _probe_e2b(e2b_key)
+        checks.append(
+            Check(
+                name="E2B credentials",
+                passed=ok,
+                detail=msg,
+                hint=(
+                    "If this fails with 401, the E2B_API_KEY is invalid. If the"
+                    " request times out, check your network / firewall."
+                    if not ok
+                    else ""
+                ),
+            )
+        )
+
+        # 4. Optional: throwaway sandbox probe
+        if deep and ok:
+            deep_check = await _probe_sandbox(e2b_key)
+            checks.append(deep_check)
+
+    # 5. Slack (optional — only when SLACK_BOT_TOKEN is configured)
+    slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
+    if slack_token:
+        checks.extend(_probe_slack(slack_token))
+
+    # 6. Optional: OpenTelemetry endpoint reachability
+    otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    if otel_endpoint:
+        ok, msg = _probe_url(otel_endpoint, timeout=3)
+        checks.append(
+            Check(
+                name="OTel endpoint",
+                passed=ok,
+                detail=msg,
+                hint=(
+                    "OTel endpoint unreachable — check OTEL_EXPORTER_OTLP_ENDPOINT"
+                    " and that your Langfuse/Phoenix/Langsmith instance is up."
+                    if not ok
+                    else ""
+                ),
+            )
+        )
+
+    return checks
+
+
+def _probe_anthropic(key: str) -> tuple[bool, str]:
+    """Cheap credential check: list models (GET, no token consumed)."""
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/models",
+        headers={
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            if resp.status == 200:
+                return True, f"OK ({resp.status})"
+            return False, f"HTTP {resp.status}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}: {exc.reason}"
+    except urllib.error.URLError as exc:
+        return False, f"network: {exc.reason}"
+    except OSError as exc:  # timeouts, DNS, etc.
+        return False, f"unreachable: {exc}"
+
+
+async def _probe_e2b(api_key: str) -> tuple[bool, str]:
+    """Attempt to list sandboxes — validates the API key without spinning up compute."""
+    from e2b import AsyncSandbox, AuthenticationException
+
+    try:
+        sandboxes = AsyncSandbox.list(api_key=api_key)
+        # AsyncSandbox.list returns a paginated iterator; pulling one page is enough
+        page = await sandboxes.next_items() if hasattr(sandboxes, "next_items") else None
+        count = len(page) if page is not None else 0
+        return True, f"OK ({count} sandbox{'es' if count != 1 else ''} visible)"
+    except AuthenticationException:
+        return False, "invalid API key (401)"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+async def _probe_sandbox(api_key: str) -> Check:
+    """Deep: spin up a sandbox, run echo, tear down. Costs a few seconds + credits."""
+    from e2b import AsyncSandbox
+
+    start = time.monotonic()
+    sbx = None
+    try:
+        sbx = await AsyncSandbox.create(api_key=api_key, timeout=60)
+        result = await sbx.commands.run("echo hello")
+        duration = time.monotonic() - start
+        ok = result.stdout.strip() == "hello"
+        detail = f"{duration:.1f}s roundtrip" if ok else f"unexpected output: {result.stdout!r}"
+        return Check(name="Sandbox echo roundtrip", passed=ok, detail=detail)
+    except Exception as exc:
+        return Check(
+            name="Sandbox echo roundtrip",
+            passed=False,
+            detail=f"{type(exc).__name__}: {exc}",
+            hint="E2B spin-up failed — check quota, region, or your network.",
+        )
+    finally:
+        if sbx is not None:
+            with contextlib.suppress(Exception):
+                await sbx.kill()
+
+
+def _probe_slack(bot_token: str) -> list[Check]:
+    """Verify the bot token + installed scopes via auth.test."""
+    try:
+        req = urllib.request.Request(
+            "https://slack.com/api/auth.test",
+            headers={"Authorization": f"Bearer {bot_token}"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:
+        return [
+            Check(
+                name="Slack auth.test",
+                passed=False,
+                detail=f"{type(exc).__name__}: {exc}",
+                hint="Bot token probe failed — verify SLACK_BOT_TOKEN.",
+            )
+        ]
+
+    if not data.get("ok"):
+        return [
+            Check(
+                name="Slack auth.test",
+                passed=False,
+                detail=f"slack_err: {data.get('error', 'unknown')}",
+                hint=(
+                    "If error is invalid_auth, the bot token is wrong."
+                    " If it's token_revoked, reinstall the app in your workspace."
+                ),
+            )
+        ]
+
+    checks = [
+        Check(
+            name="Slack auth.test",
+            passed=True,
+            detail=f"team={data.get('team')}, bot={data.get('bot_id')}",
+        )
+    ]
+
+    # Scope probe: list installed scopes from the bot token endpoint
+    # auth.test doesn't return scopes; use apps.connections.open workaround or skip.
+    # Bolt's manifest is the source of truth — we just check SLACK_SIGNING_SECRET.
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
+    checks.append(
+        Check(
+            name="SLACK_SIGNING_SECRET",
+            passed=len(signing_secret) >= 32,
+            detail="OK" if len(signing_secret) >= 32 else f"len={len(signing_secret)}",
+            hint=(
+                "Copy the signing secret from your Slack app's Basic Information page."
+                if len(signing_secret) < 32
+                else ""
+            ),
+        )
+    )
+
+    # Socket Mode app-level token (optional, only if using Socket Mode)
+    app_token = os.environ.get("SLACK_APP_TOKEN", "")
+    if app_token:
+        checks.append(
+            Check(
+                name="SLACK_APP_TOKEN format",
+                passed=app_token.startswith("xapp-"),
+                detail="starts with xapp-"
+                if app_token.startswith("xapp-")
+                else f"prefix: {app_token[:5]}",
+                hint=(
+                    "App-level tokens start with xapp-. Generate at api.slack.com"
+                    " under 'Basic Information' → 'App-Level Tokens'."
+                    if not app_token.startswith("xapp-")
+                    else ""
+                ),
+            )
+        )
+
+    return checks
+
+
+def _probe_url(url: str, timeout: int = 3) -> tuple[bool, str]:
+    """HEAD-style reachability check for arbitrary URLs."""
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return True, f"OK ({resp.status})"
+    except urllib.error.HTTPError as exc:
+        # HTTP errors still prove the endpoint is reachable
+        return True, f"HTTP {exc.code}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -20,6 +20,7 @@ from .auth import load_api_keys, verify_api_token
 from .config import load_project_dotenv as load_dotenv
 from .config import load_sandstorm_config
 from .e2b_api import webhook_request
+from .memory import memory_store
 from .models import QueryRequest
 from .sandbox import run_agent_in_sandbox
 from .store import run_store
@@ -263,6 +264,12 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
         request.model,
     )
 
+    # Persist any request-level memory before the run; memory_store is a no-op
+    # when remember is None. Done here rather than inside the async generator
+    # so the write happens synchronously before we start streaming.
+    if request.remember:
+        memory_store.remember(request.team_id, request.user_id, request.remember)
+
     async def event_generator():
         start = time.monotonic()
         run_store.create(
@@ -270,6 +277,9 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
             prompt=request.prompt,
             model=request.model,
             files_count=len(request.files) if request.files else 0,
+            team_id=request.team_id,
+            user_id=request.user_id,
+            raw_prompt=request.prompt,
         )
         cost_usd = None
         num_turns = None

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -284,6 +284,7 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
         cost_usd = None
         num_turns = None
         model = request.model
+        agent_session_id: str | None = None
         with get_tracer().start_as_current_span(
             "query",
             attributes={
@@ -302,8 +303,13 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
                             cost = parsed.get("total_cost_usd")
                             cost_usd = cost if cost is not None else parsed.get("cost_usd")
                             num_turns = parsed.get("num_turns")
+                            # Some SDK versions emit session_id on the result too
+                            agent_session_id = parsed.get("session_id") or agent_session_id
                         elif parsed.get("type") == "system" and parsed.get("subtype") == "init":
                             model = parsed.get("model") or model
+                            # Captured at init so follow-up runs in the same Slack
+                            # thread can `resume=<session_id>` to preserve context
+                            agent_session_id = parsed.get("session_id") or agent_session_id
                     except (json.JSONDecodeError, TypeError):
                         pass
                     yield {"data": line}
@@ -321,7 +327,14 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
                 record_request(model=request.model, status="ok")
                 logger.info("[%s] Query completed", req_id)
                 duration = time.monotonic() - start
-                run_store.complete(req_id, cost_usd, num_turns, duration, model)
+                run_store.complete(
+                    req_id,
+                    cost_usd,
+                    num_turns,
+                    duration,
+                    model,
+                    agent_session_id=agent_session_id,
+                )
             finally:
                 record_request_duration(time.monotonic() - start, model=request.model)
 

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -23,7 +23,7 @@ from .e2b_api import webhook_request
 from .memory import memory_store
 from .models import QueryRequest
 from .sandbox import run_agent_in_sandbox
-from .store import run_store
+from .store import build_config_snapshot, run_store
 from .telemetry import (
     get_tracer,
     record_error,
@@ -277,6 +277,15 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
             team_id=request.team_id,
             user_id=request.user_id,
             raw_prompt=request.prompt,
+            config_snapshot=build_config_snapshot(
+                {
+                    "model": request.model,
+                    "max_turns": request.max_turns,
+                    "timeout": request.timeout,
+                    "allowed_tools": request.allowed_tools,
+                    "files": request.files,
+                }
+            ),
         )
         cost_usd = None
         num_turns = None

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -264,9 +264,6 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
         request.model,
     )
 
-    # Persist any request-level memory before the run; memory_store is a no-op
-    # when remember is None. Done here rather than inside the async generator
-    # so the write happens synchronously before we start streaming.
     if request.remember:
         memory_store.remember(request.team_id, request.user_id, request.remember)
 

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -279,7 +279,7 @@ async def query(request: QueryRequest, token: str = Depends(verify_api_token)):
             attributes={
                 "sandstorm.request_id": req_id,
                 "sandstorm.model": request.model or "",
-                "sandstorm.timeout": request.timeout,
+                "sandstorm.timeout": request.timeout or 0,
                 "sandstorm.file_count": len(request.files) if request.files else 0,
             },
         ) as span:

--- a/src/sandstorm/memory.py
+++ b/src/sandstorm/memory.py
@@ -107,12 +107,12 @@ class MemoryStore:
     def _append_to_file(self, memory: Memory) -> None:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            new_file = not self._path.exists()
             with self._path.open("a") as f:
                 f.write(json.dumps(memory.to_dict()) + "\n")
-            if new_file:
-                with contextlib.suppress(OSError):
-                    os.chmod(self._path, _PRIVATE_FILE_MODE)
+            # chmod is idempotent and cheap; applying every write avoids a
+            # TOCTOU window between file creation and the permissions fix.
+            with contextlib.suppress(OSError):
+                os.chmod(self._path, _PRIVATE_FILE_MODE)
         except OSError:
             logger.warning("MemoryStore: failed to write to %s", self._path, exc_info=True)
 
@@ -131,6 +131,11 @@ class MemoryStore:
                         # Tombstone records overwrite the live copy (last-write-wins)
                         if memory.id in self._index:
                             self._index[memory.id].deleted = memory.deleted
+                            continue
+                        # A tombstone for an id that has been evicted from the
+                        # deque must not re-enter storage; it would burn a slot
+                        # and surface as a "deleted" entry in list() callers.
+                        if memory.deleted:
                             continue
                         self._memories.append(memory)
                         self._index[memory.id] = memory

--- a/src/sandstorm/memory.py
+++ b/src/sandstorm/memory.py
@@ -9,8 +9,10 @@ The agent never calls this as a tool — the host injects remembered content int
 `system_prompt_append` at query time via `as_prompt_prefix()`.
 """
 
+import contextlib
 import json
 import logging
+import os
 import uuid
 from collections import deque
 from dataclasses import asdict, dataclass
@@ -20,6 +22,9 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _LOCAL_TEAM_ID = "__local__"
+# Memories often contain credentials ("my openai key is sk-..."). Keep the
+# on-disk file readable only by the owning user.
+_PRIVATE_FILE_MODE = 0o600
 
 
 @dataclass
@@ -102,8 +107,12 @@ class MemoryStore:
     def _append_to_file(self, memory: Memory) -> None:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
+            new_file = not self._path.exists()
             with self._path.open("a") as f:
                 f.write(json.dumps(memory.to_dict()) + "\n")
+            if new_file:
+                with contextlib.suppress(OSError):
+                    os.chmod(self._path, _PRIVATE_FILE_MODE)
         except OSError:
             logger.warning("MemoryStore: failed to write to %s", self._path, exc_info=True)
 

--- a/src/sandstorm/memory.py
+++ b/src/sandstorm/memory.py
@@ -1,0 +1,135 @@
+"""User-scoped memory, JSONL-backed. Mirrors the RunStore shape in store.py.
+
+Memories are append-only with tombstone records for deletes, so the storage file
+stays simple (`.sandstorm/memories.jsonl`). The store is keyed on
+`(team_id, user_id)` — there is no cross-workspace sharing. For CLI/HTTP runs
+without a Slack team context, `team_id="__local__"` is the canonical default.
+
+The agent never calls this as a tool — the host injects remembered content into
+`system_prompt_append` at query time via `as_prompt_prefix()`.
+"""
+
+import json
+import logging
+import uuid
+from collections import deque
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_LOCAL_TEAM_ID = "__local__"
+
+
+@dataclass
+class Memory:
+    id: str
+    team_id: str
+    user_id: str
+    text: str
+    created_at: str  # ISO UTC
+    deleted: bool = False  # tombstone for forget()
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class MemoryStore:
+    """In-memory deque + JSONL for persistence. Tombstone records encode deletes."""
+
+    def __init__(self, path: str | Path = ".sandstorm/memories.jsonl", maxlen: int = 10_000):
+        self._path = Path(path)
+        self._maxlen = maxlen
+        self._memories: deque[Memory] = deque(maxlen=maxlen)
+        self._index: dict[str, Memory] = {}
+        self._load_from_file()
+
+    @staticmethod
+    def _scope(team_id: str | None, user_id: str | None) -> tuple[str, str]:
+        return (team_id or _LOCAL_TEAM_ID, user_id or _LOCAL_TEAM_ID)
+
+    def remember(self, team_id: str | None, user_id: str | None, text: str) -> Memory:
+        team, user = self._scope(team_id, user_id)
+        memory = Memory(
+            id=uuid.uuid4().hex,
+            team_id=team,
+            user_id=user,
+            text=text.strip(),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        if len(self._memories) == self._maxlen:
+            evicted = self._memories[0]
+            self._index.pop(evicted.id, None)
+        self._memories.append(memory)
+        self._index[memory.id] = memory
+        self._append_to_file(memory)
+        return memory
+
+    def forget(self, team_id: str | None, user_id: str | None, substring: str) -> int:
+        """Tombstone any live memory whose text contains `substring` (case-insensitive).
+        Returns number of memories deleted."""
+        team, user = self._scope(team_id, user_id)
+        needle = substring.lower()
+        deleted = 0
+        for memory in list(self._memories):
+            if (
+                not memory.deleted
+                and memory.team_id == team
+                and memory.user_id == user
+                and needle in memory.text.lower()
+            ):
+                memory.deleted = True
+                self._append_to_file(memory)
+                deleted += 1
+        return deleted
+
+    def list(self, team_id: str | None, user_id: str | None) -> list[Memory]:
+        team, user = self._scope(team_id, user_id)
+        return [
+            m for m in self._memories if not m.deleted and m.team_id == team and m.user_id == user
+        ]
+
+    def as_prompt_prefix(self, team_id: str | None, user_id: str | None) -> str:
+        """Format memories as a bullet list suitable for prepending to system_prompt_append.
+        Returns an empty string when no memories exist — callers can safely concatenate."""
+        memories = self.list(team_id, user_id)
+        if not memories:
+            return ""
+        bullets = "\n".join(f"- {m.text}" for m in memories)
+        return f"User memory (persisted across sessions):\n{bullets}\n\n"
+
+    def _append_to_file(self, memory: Memory) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("a") as f:
+                f.write(json.dumps(memory.to_dict()) + "\n")
+        except OSError:
+            logger.warning("MemoryStore: failed to write to %s", self._path, exc_info=True)
+
+    def _load_from_file(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            with self._path.open() as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        memory = Memory(**data)
+                        # Tombstone records overwrite the live copy (last-write-wins)
+                        if memory.id in self._index:
+                            self._index[memory.id].deleted = memory.deleted
+                            continue
+                        self._memories.append(memory)
+                        self._index[memory.id] = memory
+                    except (json.JSONDecodeError, TypeError, KeyError):
+                        logger.warning("MemoryStore: skipping malformed line in %s", self._path)
+        except OSError:
+            logger.warning("MemoryStore: failed to read %s", self._path, exc_info=True)
+        self._index = {m.id: m for m in self._memories}
+
+
+memory_store = MemoryStore()

--- a/src/sandstorm/models.py
+++ b/src/sandstorm/models.py
@@ -92,6 +92,24 @@ class QueryRequest(BaseModel):
         description="Whitelist agents by name (subset of sandstorm.json). None = use all.",
     )
 
+    # Agent SDK session controls — enables ds replay and Slack thread resume
+    resume: str | None = Field(
+        default=None,
+        description=(
+            "Agent SDK session ID to resume. Combined with fork_session, lets `ds replay`"
+            " branch a prior session with a new model/config while preserving its transcript."
+        ),
+    )
+    fork_session: bool | None = Field(
+        default=None,
+        description="When resuming a session, fork into a new branch instead of continuing.",
+    )
+    max_budget_usd: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Hard cap on run cost in USD. Passed as maxBudgetUsd to the Agent SDK.",
+    )
+
     # User memory (context injection — not a tool the agent decides to call)
     team_id: str | None = Field(
         default=None,

--- a/src/sandstorm/models.py
+++ b/src/sandstorm/models.py
@@ -92,6 +92,26 @@ class QueryRequest(BaseModel):
         description="Whitelist agents by name (subset of sandstorm.json). None = use all.",
     )
 
+    # User memory (context injection — not a tool the agent decides to call)
+    team_id: str | None = Field(
+        default=None,
+        description=(
+            "Scope for memory lookup/write. Slack workspaces pass their team_id;"
+            " CLI/HTTP runs default to '__local__' when omitted."
+        ),
+    )
+    user_id: str | None = Field(
+        default=None,
+        description="Scope for memory lookup/write. Defaults to '__local__'.",
+    )
+    remember: str | None = Field(
+        default=None,
+        description=(
+            "Optional memory text to persist for (team_id, user_id) before the run."
+            " Also available via Slack slash command /remember."
+        ),
+    )
+
     # Extra inline definitions (merged before whitelisting)
     extra_agents: dict[str, dict] | None = Field(
         default=None,

--- a/src/sandstorm/runner.mjs
+++ b/src/sandstorm/runner.mjs
@@ -30,6 +30,11 @@ const fieldMap = {
   output_format: "outputFormat",
   agents: "agents",
   allowed_tools: "allowedTools",
+  resume: "resume",
+  resume_session_at: "resumeSessionAt",
+  fork_session: "forkSession",
+  include_partial_messages: "includePartialMessages",
+  max_budget_usd: "maxBudgetUsd",
 };
 for (const [src, dst] of Object.entries(fieldMap)) {
   if (config[src] !== undefined && config[src] !== null) options[dst] = config[src];

--- a/src/sandstorm/sandbox.py
+++ b/src/sandstorm/sandbox.py
@@ -218,11 +218,7 @@ async def run_agent_in_sandbox(
         input_file_names.update(binary_files.keys())
 
     if sandbox_id:
-        # --- Reconnect path: reuse an existing sandbox ---
-        # AsyncSandbox.connect() auto-resumes a paused sandbox. If the ID has
-        # expired or been killed, NotFoundException bubbles up — slack.py's
-        # pool layer catches the failure via reuse_succeeded=False and
-        # creates a fresh sandbox instead.
+        # connect() auto-resumes a paused sandbox; callers handle NotFoundException.
         logger.info("[%s] Reconnecting to sandbox %s", request_id, sandbox_id)
         sbx = await AsyncSandbox.connect(sandbox_id, api_key=request.e2b_api_key)
         await sbx.set_timeout(timeout)
@@ -430,10 +426,8 @@ async def run_agent_in_sandbox(
                     task.result()
                 except Exception:
                     logger.warning("[%s] Task exception suppressed", request_id, exc_info=True)
-            # Pause instead of leaving the sandbox running — filesystem + process
-            # state persist across Slack messages and even across server restarts,
-            # while compute stops billing. AsyncSandbox.connect() auto-resumes on
-            # the next message in the thread.
+            # Pause preserves filesystem + running processes and stops billing
+            # for compute. connect() on the next message auto-resumes.
             try:
                 await sbx.pause()
                 logger.info("[%s] Paused sandbox %s", request_id, sbx.sandbox_id)

--- a/src/sandstorm/sandbox.py
+++ b/src/sandstorm/sandbox.py
@@ -219,6 +219,10 @@ async def run_agent_in_sandbox(
 
     if sandbox_id:
         # --- Reconnect path: reuse an existing sandbox ---
+        # AsyncSandbox.connect() auto-resumes a paused sandbox. If the ID has
+        # expired or been killed, NotFoundException bubbles up — slack.py's
+        # pool layer catches the failure via reuse_succeeded=False and
+        # creates a fresh sandbox instead.
         logger.info("[%s] Reconnecting to sandbox %s", request_id, sandbox_id)
         sbx = await AsyncSandbox.connect(sandbox_id, api_key=request.e2b_api_key)
         await sbx.set_timeout(timeout)
@@ -426,11 +430,20 @@ async def run_agent_in_sandbox(
                     task.result()
                 except Exception:
                     logger.warning("[%s] Task exception suppressed", request_id, exc_info=True)
-            logger.info(
-                "[%s] Keeping sandbox %s alive (timeout=%ds)",
-                request_id,
-                sbx.sandbox_id,
-                timeout,
-            )
+            # Pause instead of leaving the sandbox running — filesystem + process
+            # state persist across Slack messages and even across server restarts,
+            # while compute stops billing. AsyncSandbox.connect() auto-resumes on
+            # the next message in the thread.
+            try:
+                await sbx.pause()
+                logger.info("[%s] Paused sandbox %s", request_id, sbx.sandbox_id)
+            except Exception:
+                logger.warning(
+                    "[%s] Failed to pause sandbox %s — leaving it running (timeout=%ds)",
+                    request_id,
+                    sbx.sandbox_id,
+                    timeout,
+                    exc_info=True,
+                )
         else:
             await _cleanup(task, sbx, request_id)

--- a/src/sandstorm/sandbox.py
+++ b/src/sandstorm/sandbox.py
@@ -40,7 +40,7 @@ TEMPLATE = os.environ.get("SANDSTORM_TEMPLATE", "work-43ca/sandstorm")
 FALLBACK_TEMPLATE = "claude-code"
 
 # Claude Agent SDK version — single source of truth (also imported by build_template.py)
-SDK_VERSION = "0.2.42"
+SDK_VERSION = "0.2.112"
 
 _QUEUE_MAXSIZE = 10_000  # Buffer for sync→async bridge; drops if consumer is slow
 _SDK_INSTALL_TIMEOUT = 120  # Fallback npm install timeout (seconds)

--- a/src/sandstorm/sandbox.py
+++ b/src/sandstorm/sandbox.py
@@ -427,17 +427,20 @@ async def run_agent_in_sandbox(
                 except Exception:
                     logger.warning("[%s] Task exception suppressed", request_id, exc_info=True)
             # Pause preserves filesystem + running processes and stops billing
-            # for compute. connect() on the next message auto-resumes.
+            # for compute. connect() on the next message auto-resumes. If pause
+            # fails, fall back to kill() so we never orphan a billable sandbox.
             try:
                 await sbx.pause()
                 logger.info("[%s] Paused sandbox %s", request_id, sbx.sandbox_id)
             except Exception:
-                logger.warning(
-                    "[%s] Failed to pause sandbox %s — leaving it running (timeout=%ds)",
+                logger.error(
+                    "[%s] Failed to pause sandbox %s — killing instead to avoid "
+                    "orphaning a billable sandbox",
                     request_id,
                     sbx.sandbox_id,
-                    timeout,
                     exc_info=True,
                 )
+                with contextlib.suppress(Exception):
+                    await sbx.kill()
         else:
             await _cleanup(task, sbx, request_id)

--- a/src/sandstorm/slack-manifest.yaml
+++ b/src/sandstorm/slack-manifest.yaml
@@ -17,6 +17,22 @@ features:
         message: "Compare these competitor pages..."
       - title: Draft content
         message: "Draft a summary from this document..."
+  slash_commands:
+    - command: /remember
+      description: Remember a fact for your future Sandstorm agent runs
+      usage_hint: "likes oat milk"
+      should_escape: false
+    - command: /forget
+      description: Forget any remembered fact containing a substring
+      usage_hint: "oat milk"
+      should_escape: false
+    - command: /memories
+      description: List the facts Sandstorm remembers for you
+      should_escape: false
+    - command: /model
+      description: Override the model used for this thread (ephemeral until restart)
+      usage_hint: "claude-haiku-4-5-20251001 | clear"
+      should_escape: false
 oauth_config:
   scopes:
     bot:
@@ -29,6 +45,7 @@ oauth_config:
       - im:history
       - files:read
       - reactions:write
+      - commands
 settings:
   event_subscriptions:
     bot_events:

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -618,14 +618,14 @@ def create_slack_app(
         set_status: Callable | None = None,
     ) -> dict:
         """Run agent with sandbox reuse, pool management, and eviction."""
-        team_id = context.get("team_id") or ""
-        key = (team_id, channel, thread_ts)
+        tenant = context.get("enterprise_id") or context.get("team_id") or ""
+        key = (tenant, channel, thread_ts)
         if key not in _sandbox_pool:
             # Cold start (or server restart). Look up the prior Run for this
             # thread and resume its paused sandbox if it still exists; E2B's
             # connect() auto-resumes. On failure the generic reuse-error path
             # handles the fallback.
-            prior = run_store.find_thread_session(team_id, channel, thread_ts)
+            prior = run_store.find_thread_session(tenant, channel, thread_ts)
             initial_id = prior.sandbox_id if prior else None
             _sandbox_pool[key] = (initial_id, asyncio.Lock())
         _, lock = _sandbox_pool[key]
@@ -729,13 +729,14 @@ def create_slack_app(
             await client.reactions_add(channel=channel, timestamp=event["ts"], name="eyes")
 
         run_id = uuid.uuid4().hex[:8]
+        tenant = context.get("enterprise_id") or context.get("team_id")
         request, binary_files = await _prepare_prompt(
             client,
             channel,
             thread_ts,
             bot_user_id,
             prompt,
-            team_id=context.get("team_id"),
+            team_id=tenant,
             user_id=user_id,
         )
         await _run_in_sandbox_pool(
@@ -793,13 +794,14 @@ def create_slack_app(
 
         await set_status("Spinning up sandbox...")
         run_id = uuid.uuid4().hex[:8]
+        tenant = context.get("enterprise_id") or context.get("team_id")
         request, binary_files = await _prepare_prompt(
             client,
             channel_id,
             thread_ts,
             bot_user_id,
             prompt,
-            team_id=context.get("team_id"),
+            team_id=tenant,
             user_id=user_id,
         )
         await _run_in_sandbox_pool(
@@ -869,7 +871,12 @@ def create_slack_app(
     # bot scope for these to appear in the workspace — see slack-manifest.yaml.
 
     def _command_scope(command) -> tuple[str | None, str | None]:
-        return command.get("team_id"), command.get("user_id")
+        # On Enterprise Grid, the bot is installed on the enterprise and the
+        # sub-workspace team_id rotates per channel. Prefer enterprise_id so
+        # memories stay scoped to the whole tenant; fall back to team_id for
+        # single-workspace installs where enterprise_id is absent.
+        tenant = command.get("enterprise_id") or command.get("team_id")
+        return tenant, command.get("user_id")
 
     @app.command("/remember")
     async def handle_remember(ack, command, respond):
@@ -916,13 +923,13 @@ def create_slack_app(
     async def handle_model(ack, command, respond):
         await ack()
         # Slash commands do not carry thread_ts, so /model scopes to
-        # (team, channel, user) instead of per-thread. The override then
+        # (tenant, channel, user) instead of per-thread. The override then
         # applies to that user's next @mention or DM in this channel.
         model = (command.get("text") or "").strip()
-        team_id = command.get("team_id") or ""
+        tenant = command.get("enterprise_id") or command.get("team_id") or ""
         channel = command.get("channel_id") or ""
         user_id = command.get("user_id") or ""
-        key = (team_id, channel, f"user:{user_id}")
+        key = (tenant, channel, f"user:{user_id}")
         if not model:
             current = _thread_model_overrides.get(key)
             await respond(

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -364,6 +364,7 @@ async def _stream_to_slack(
                 "model": request.model,
                 "allowed_tools": request.allowed_tools,
                 "timeout": request.timeout,
+                "files": request.files,
             }
         ),
     )

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -341,6 +341,7 @@ async def _stream_to_slack(
         "num_turns": None,
         "duration_secs": None,
         "error": None,
+        "agent_session_id": None,
     }
 
     start = time.monotonic()
@@ -352,6 +353,17 @@ async def _stream_to_slack(
         prompt=request.prompt,
         model=request.model,
         files_count=len(request.files) if request.files else 0,
+        raw_prompt=request.prompt,
+        team_id=request.team_id,
+        user_id=request.user_id,
+        channel_id=channel,
+        thread_ts=thread_ts,
+        sandbox_id=sandbox_id,
+        config_snapshot={
+            "model": request.model,
+            "allowed_tools": request.allowed_tools,
+            "timeout": request.timeout,
+        },
     )
 
     try:
@@ -374,6 +386,10 @@ async def _stream_to_slack(
             if event_type == "system" and event.get("subtype") == "init":
                 model = event.get("model")
                 metadata["model"] = model
+                # Captured so the next message in this thread can resume the session
+                metadata["agent_session_id"] = (
+                    event.get("session_id") or metadata["agent_session_id"]
+                )
                 if set_status:
                     await set_status(f"Running agent on {model}...")
 
@@ -423,12 +439,23 @@ async def _stream_to_slack(
                 except Exception:
                     logger.error("[%s] streamer.stop failed", run_id, exc_info=True)
 
+                # Some SDK versions also surface session_id on the result event
+                metadata["agent_session_id"] = (
+                    event.get("session_id") or metadata["agent_session_id"]
+                )
+                if metadata["agent_session_id"] is None:
+                    logger.info(
+                        "[%s] No agent_session_id captured — next thread message "
+                        "will not resume the session",
+                        run_id,
+                    )
                 run_store.complete(
                     run_id,
                     cost_usd=metadata["cost_usd"],
                     num_turns=metadata["num_turns"],
                     duration_secs=metadata["duration_secs"],
                     model=metadata["model"],
+                    agent_session_id=metadata["agent_session_id"],
                 )
 
             elif event_type == "error":
@@ -558,7 +585,28 @@ def create_slack_app(
             user_id=user_id,
             model=model_override,
         )
+
+        # Resume the prior agent session in this thread so the model keeps its
+        # transcript + planning state across messages. Falls back to the
+        # _gather_thread_context text-based approach if no session_id is saved.
+        prior_session_id = _find_thread_session(team_id, channel, thread_ts)
+        if prior_session_id:
+            request.resume = prior_session_id
+
         return request, binary_files
+
+    def _find_thread_session(team_id: str | None, channel: str, thread_ts: str) -> str | None:
+        """Most recent completed Run in this thread that recorded a session_id."""
+        for run in reversed(run_store._runs):
+            if (
+                run.team_id == team_id
+                and run.channel_id == channel
+                and run.thread_ts == thread_ts
+                and run.agent_session_id
+                and run.status == "completed"
+            ):
+                return run.agent_session_id
+        return None
 
     async def _run_in_sandbox_pool(
         *,

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -411,6 +411,22 @@ async def _stream_to_slack(
                         logger.info("[%s] Tool: %s", run_id, tool_name)
                         if set_status:
                             await set_status(f"Using {tool_name}...")
+                        else:
+                            # @mention path has no set_status — inline a compact
+                            # tool breadcrumb in the main stream so the user can
+                            # see what the agent is doing instead of silent
+                            # pauses during long tool chains.
+                            try:
+                                await streamer.append(
+                                    markdown_text=f"\n_:hammer_and_wrench: {tool_name}_\n"
+                                )
+                                has_streamed_text = True
+                            except Exception:
+                                logger.error(
+                                    "[%s] streamer.append (tool crumb) failed",
+                                    run_id,
+                                    exc_info=True,
+                                )
 
             elif event_type == "result":
                 cost = event.get("total_cost_usd")

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from .memory import memory_store
 from .models import QueryRequest
 from .sandbox import run_agent_in_sandbox
-from .store import run_store
+from .store import build_config_snapshot, run_store
 
 if TYPE_CHECKING:
     from slack_bolt.async_app import AsyncApp
@@ -359,11 +359,13 @@ async def _stream_to_slack(
         channel_id=channel,
         thread_ts=thread_ts,
         sandbox_id=sandbox_id,
-        config_snapshot={
-            "model": request.model,
-            "allowed_tools": request.allowed_tools,
-            "timeout": request.timeout,
-        },
+        config_snapshot=build_config_snapshot(
+            {
+                "model": request.model,
+                "allowed_tools": request.allowed_tools,
+                "timeout": request.timeout,
+            }
+        ),
     )
 
     try:
@@ -412,10 +414,6 @@ async def _stream_to_slack(
                         if set_status:
                             await set_status(f"Using {tool_name}...")
                         else:
-                            # @mention path has no set_status — inline a compact
-                            # tool breadcrumb in the main stream so the user can
-                            # see what the agent is doing instead of silent
-                            # pauses during long tool chains.
                             try:
                                 await streamer.append(
                                     markdown_text=f"\n_:hammer_and_wrench: {tool_name}_\n"
@@ -555,15 +553,12 @@ def create_slack_app(
         process_before_response=process_before_response,
     )
 
-    # Sandbox reuse pool: (team_id, channel, thread_ts) -> (sandbox_id, lock)
-    # Lock serializes concurrent @mentions in the same thread. Including team_id
-    # in the key is defensive for future multi-workspace deployments and prevents
-    # cross-workspace collisions if the same channel/thread IDs ever collide.
+    # Sandbox reuse pool: (team_id, channel, thread_ts) -> (sandbox_id, lock).
+    # Lock serializes concurrent @mentions in the same thread.
     _sandbox_pool: dict[tuple[str, str, str], tuple[str | None, asyncio.Lock]] = {}
 
-    # Per-thread model override set via /model slash command. Keyed the same as
-    # _sandbox_pool. In-memory only — intentionally lost on restart so a thread's
-    # model reverts to the sandstorm.json default after redeploy.
+    # Per-user-per-channel model override from /model. In-memory only:
+    # intentionally lost on restart so overrides don't outlive the process.
     _thread_model_overrides: dict[tuple[str, str, str], str] = {}
 
     # ── Shared helpers (close over _sandbox_pool) ──
@@ -592,8 +587,9 @@ def create_slack_app(
             file_list = "\n".join(f"- /home/user/{f}" for f in all_files)
             full_prompt += f"\n\nFiles available in your working directory:\n{file_list}"
 
-        override_key = (team_id or "", channel, thread_ts)
-        model_override = _thread_model_overrides.get(override_key)
+        model_override = _thread_model_overrides.get(
+            (team_id or "", channel, f"user:{user_id or ''}")
+        )
         request = _build_query_request(
             full_prompt,
             text_files or None,
@@ -602,27 +598,11 @@ def create_slack_app(
             model=model_override,
         )
 
-        # Resume the prior agent session in this thread so the model keeps its
-        # transcript + planning state across messages. Falls back to the
-        # _gather_thread_context text-based approach if no session_id is saved.
-        prior_session_id = _find_thread_session(team_id, channel, thread_ts)
-        if prior_session_id:
-            request.resume = prior_session_id
+        prior_run = run_store.find_thread_session(team_id, channel, thread_ts)
+        if prior_run and prior_run.agent_session_id:
+            request.resume = prior_run.agent_session_id
 
         return request, binary_files
-
-    def _find_thread_session(team_id: str | None, channel: str, thread_ts: str) -> str | None:
-        """Most recent completed Run in this thread that recorded a session_id."""
-        for run in reversed(run_store._runs):
-            if (
-                run.team_id == team_id
-                and run.channel_id == channel
-                and run.thread_ts == thread_ts
-                and run.agent_session_id
-                and run.status == "completed"
-            ):
-                return run.agent_session_id
-        return None
 
     async def _run_in_sandbox_pool(
         *,
@@ -637,9 +617,16 @@ def create_slack_app(
         set_status: Callable | None = None,
     ) -> dict:
         """Run agent with sandbox reuse, pool management, and eviction."""
-        key = (context.get("team_id") or "", channel, thread_ts)
+        team_id = context.get("team_id") or ""
+        key = (team_id, channel, thread_ts)
         if key not in _sandbox_pool:
-            _sandbox_pool[key] = (None, asyncio.Lock())
+            # Cold start (or server restart). Look up the prior Run for this
+            # thread and resume its paused sandbox if it still exists; E2B's
+            # connect() auto-resumes. On failure the generic reuse-error path
+            # handles the fallback.
+            prior = run_store.find_thread_session(team_id, channel, thread_ts)
+            initial_id = prior.sandbox_id if prior else None
+            _sandbox_pool[key] = (initial_id, asyncio.Lock())
         _, lock = _sandbox_pool[key]
 
         async with lock:
@@ -927,28 +914,31 @@ def create_slack_app(
     @app.command("/model")
     async def handle_model(ack, command, respond):
         await ack()
+        # Slash commands do not carry thread_ts, so /model scopes to
+        # (team, channel, user) instead of per-thread. The override then
+        # applies to that user's next @mention or DM in this channel.
         model = (command.get("text") or "").strip()
-        channel = command.get("channel_id") or ""
-        thread_ts = command.get("thread_ts") or command.get("trigger_id") or ""
         team_id = command.get("team_id") or ""
-        key = (team_id, channel, thread_ts)
+        channel = command.get("channel_id") or ""
+        user_id = command.get("user_id") or ""
+        key = (team_id, channel, f"user:{user_id}")
         if not model:
             current = _thread_model_overrides.get(key)
             await respond(
                 text=(
-                    f"Current thread model override: `{current}`"
+                    f"Current model override in this channel: `{current}`"
                     if current
-                    else "No model override set for this thread."
+                    else "No model override set in this channel."
                 )
                 + " Pass a model name to set one: `/model claude-haiku-4-5-20251001`."
             )
             return
         if model.lower() in {"clear", "reset", "none"}:
             _thread_model_overrides.pop(key, None)
-            await respond(text="Cleared model override — thread will use the configured default.")
+            await respond(text="Cleared model override. Will use the configured default.")
             return
         _thread_model_overrides[key] = model
-        await respond(text=f"Model override set for this thread: `{model}`")
+        await respond(text=f"Model override set for this channel: `{model}`")
 
     return app
 

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -14,6 +14,7 @@ import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from .memory import memory_store
 from .models import QueryRequest
 from .sandbox import run_agent_in_sandbox
 from .store import run_store
@@ -101,14 +102,23 @@ def _build_metadata_blocks(
 # ── Query builder ─────────────────────────────────────────────────────────────
 
 
-def _build_query_request(prompt: str, files: dict[str, str] | None = None) -> QueryRequest:
+def _build_query_request(
+    prompt: str,
+    files: dict[str, str] | None = None,
+    team_id: str | None = None,
+    user_id: str | None = None,
+    model: str | None = None,
+) -> QueryRequest:
     """Build QueryRequest from prompt, deferring model/timeout to sandstorm.json.
+
+    When team_id/user_id are passed, the server-side memory injection in
+    config._build_agent_config will scope remembered context to that user.
 
     API keys resolved by QueryRequest.resolve_api_keys() as usual.
     """
     return QueryRequest(
         prompt=prompt,
-        model=None,
+        model=model,
         timeout=None,
         files=files,
         output_format={},  # Slack is conversational — skip structured output
@@ -116,6 +126,8 @@ def _build_query_request(prompt: str, files: dict[str, str] | None = None) -> Qu
         e2b_api_key=None,
         openrouter_api_key=None,
         max_turns=None,
+        team_id=team_id,
+        user_id=user_id,
     )
 
 
@@ -500,14 +512,27 @@ def create_slack_app(
         process_before_response=process_before_response,
     )
 
-    # Sandbox reuse pool: (channel, thread_ts) -> (sandbox_id, lock)
-    # Lock serializes concurrent @mentions in the same thread
-    _sandbox_pool: dict[tuple[str, str], tuple[str | None, asyncio.Lock]] = {}
+    # Sandbox reuse pool: (team_id, channel, thread_ts) -> (sandbox_id, lock)
+    # Lock serializes concurrent @mentions in the same thread. Including team_id
+    # in the key is defensive for future multi-workspace deployments and prevents
+    # cross-workspace collisions if the same channel/thread IDs ever collide.
+    _sandbox_pool: dict[tuple[str, str, str], tuple[str | None, asyncio.Lock]] = {}
+
+    # Per-thread model override set via /model slash command. Keyed the same as
+    # _sandbox_pool. In-memory only — intentionally lost on restart so a thread's
+    # model reverts to the sandstorm.json default after redeploy.
+    _thread_model_overrides: dict[tuple[str, str, str], str] = {}
 
     # ── Shared helpers (close over _sandbox_pool) ──
 
     async def _prepare_prompt(
-        client, channel: str, thread_ts: str, bot_user_id: str, prompt: str
+        client,
+        channel: str,
+        thread_ts: str,
+        bot_user_id: str,
+        prompt: str,
+        team_id: str | None = None,
+        user_id: str | None = None,
     ) -> tuple[QueryRequest, dict[str, bytes]]:
         """Fetch thread context, resolve names, download files, build request."""
         messages = await _fetch_thread_messages(client, channel, thread_ts)
@@ -524,7 +549,15 @@ def create_slack_app(
             file_list = "\n".join(f"- /home/user/{f}" for f in all_files)
             full_prompt += f"\n\nFiles available in your working directory:\n{file_list}"
 
-        request = _build_query_request(full_prompt, text_files or None)
+        override_key = (team_id or "", channel, thread_ts)
+        model_override = _thread_model_overrides.get(override_key)
+        request = _build_query_request(
+            full_prompt,
+            text_files or None,
+            team_id=team_id,
+            user_id=user_id,
+            model=model_override,
+        )
         return request, binary_files
 
     async def _run_in_sandbox_pool(
@@ -540,7 +573,7 @@ def create_slack_app(
         set_status: Callable | None = None,
     ) -> dict:
         """Run agent with sandbox reuse, pool management, and eviction."""
-        key = (channel, thread_ts)
+        key = (context.get("team_id") or "", channel, thread_ts)
         if key not in _sandbox_pool:
             _sandbox_pool[key] = (None, asyncio.Lock())
         _, lock = _sandbox_pool[key]
@@ -645,7 +678,13 @@ def create_slack_app(
 
         run_id = uuid.uuid4().hex[:8]
         request, binary_files = await _prepare_prompt(
-            client, channel, thread_ts, bot_user_id, prompt
+            client,
+            channel,
+            thread_ts,
+            bot_user_id,
+            prompt,
+            team_id=context.get("team_id"),
+            user_id=user_id,
         )
         await _run_in_sandbox_pool(
             request=request,
@@ -703,7 +742,13 @@ def create_slack_app(
         await set_status("Spinning up sandbox...")
         run_id = uuid.uuid4().hex[:8]
         request, binary_files = await _prepare_prompt(
-            client, channel_id, thread_ts, bot_user_id, prompt
+            client,
+            channel_id,
+            thread_ts,
+            bot_user_id,
+            prompt,
+            team_id=context.get("team_id"),
+            user_id=user_id,
         )
         await _run_in_sandbox_pool(
             request=request,
@@ -760,6 +805,86 @@ def create_slack_app(
             emoji="\U0001f44e",
             label="found this not helpful",
         )
+
+    # ── 4. Memory + model slash commands ──
+    #
+    # /remember <text>           persist a fact for (team_id, user_id)
+    # /forget <substring>        tombstone memories containing substring
+    # /memories                  list live memories
+    # /model <name>              override the model for this thread until restart
+    #
+    # All four are scoped to (team_id, user_id). Slack requires the `commands`
+    # bot scope for these to appear in the workspace — see slack-manifest.yaml.
+
+    def _command_scope(command) -> tuple[str | None, str | None]:
+        return command.get("team_id"), command.get("user_id")
+
+    @app.command("/remember")
+    async def handle_remember(ack, command, respond):
+        await ack()
+        text = (command.get("text") or "").strip()
+        if not text:
+            await respond(text="Usage: `/remember <fact>`. Example: `/remember likes oat milk`.")
+            return
+        team_id, user_id = _command_scope(command)
+        memory_store.remember(team_id, user_id, text)
+        await respond(text=f"Remembered: _{text}_")
+
+    @app.command("/forget")
+    async def handle_forget(ack, command, respond):
+        await ack()
+        substring = (command.get("text") or "").strip()
+        if not substring:
+            await respond(
+                text=(
+                    "Usage: `/forget <substring>`. Example: `/forget oat milk`."
+                    " Forgets every memory whose text contains the substring (case-insensitive)."
+                )
+            )
+            return
+        team_id, user_id = _command_scope(command)
+        deleted = memory_store.forget(team_id, user_id, substring)
+        if deleted:
+            await respond(text=f"Forgot {deleted} memor{'y' if deleted == 1 else 'ies'}.")
+        else:
+            await respond(text=f"No memory matched `{substring}`.")
+
+    @app.command("/memories")
+    async def handle_memories(ack, command, respond):
+        await ack()
+        team_id, user_id = _command_scope(command)
+        memories = memory_store.list(team_id, user_id)
+        if not memories:
+            await respond(text="No memories yet. Use `/remember <fact>` to add one.")
+            return
+        lines = [f"{i + 1}. {m.text}" for i, m in enumerate(memories)]
+        await respond(text="Your memories:\n" + "\n".join(lines))
+
+    @app.command("/model")
+    async def handle_model(ack, command, respond):
+        await ack()
+        model = (command.get("text") or "").strip()
+        channel = command.get("channel_id") or ""
+        thread_ts = command.get("thread_ts") or command.get("trigger_id") or ""
+        team_id = command.get("team_id") or ""
+        key = (team_id, channel, thread_ts)
+        if not model:
+            current = _thread_model_overrides.get(key)
+            await respond(
+                text=(
+                    f"Current thread model override: `{current}`"
+                    if current
+                    else "No model override set for this thread."
+                )
+                + " Pass a model name to set one: `/model claude-haiku-4-5-20251001`."
+            )
+            return
+        if model.lower() in {"clear", "reset", "none"}:
+            _thread_model_overrides.pop(key, None)
+            await respond(text="Cleared model override — thread will use the configured default.")
+            return
+        _thread_model_overrides[key] = model
+        await respond(text=f"Model override set for this thread: `{model}`")
 
     return app
 

--- a/src/sandstorm/starter_catalog.py
+++ b/src/sandstorm/starter_catalog.py
@@ -78,6 +78,18 @@ STARTERS: tuple[StarterDefinition, ...] = (
             "-f /path/to/requirements.txt -f /path/to/src/auth.py"
         ),
     ),
+    StarterDefinition(
+        slug="code-review",
+        title="Code Review",
+        description=(
+            "Review GitHub pull requests — pulls the diff, checks tests, posts inline"
+            " comments with GitHub MCP."
+        ),
+        next_step_command=(
+            'ds "Review PR 123 in owner/repo — focus on security and API breakage"'
+        ),
+        aliases=("pr-review",),
+    ),
 )
 
 _STARTER_BY_SLUG = {starter.slug: starter for starter in STARTERS}

--- a/src/sandstorm/starters/code-review/README.md
+++ b/src/sandstorm/starters/code-review/README.md
@@ -1,0 +1,45 @@
+# Code Review
+
+Starter for an agent that reviews pull requests — pulls the diff from GitHub,
+checks out the repo, runs the tests, and posts a review with inline comments.
+
+## Run it
+
+From the repo root:
+
+```bash
+ds "Review PR 123 in owner/repo — focus on security and API breakage"
+```
+
+In Slack (after `ds slack start`):
+
+```
+@Sandstorm review PR https://github.com/owner/repo/pull/123
+```
+
+## Environment
+
+Create `.env` from `.env.example` and populate:
+
+- `ANTHROPIC_API_KEY`
+- `E2B_API_KEY`
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — a fine-grained PAT with `Contents: read`,
+  `Pull requests: read/write`, and `Metadata: read` on the target repo(s)
+- `LINEAR_API_KEY` — optional, lets the agent cross-reference tickets when
+  the PR title or body mentions one
+
+## Example prompts
+
+- Review PR 123 in owner/repo and leave inline comments on material issues.
+- Compare this PR against the description — call out anything out-of-scope.
+- What's blocking this PR from shipping? Read the CI logs and diff first.
+- Triage the last five PRs in owner/repo by risk and suggest review order.
+
+## Tuning
+
+1. Add team conventions, required checks, or banned patterns to
+   `system_prompt_append` in `sandstorm.json`.
+2. Narrow `allowed_tools` if the agent should not be allowed to run tests
+   locally — e.g. drop `Bash` to make it a pure read-only reviewer.
+3. Switch `model` to `"opus"` for dense, complex reviews and `"haiku"` for
+   high-volume triage of small PRs.

--- a/src/sandstorm/starters/code-review/README.md
+++ b/src/sandstorm/starters/code-review/README.md
@@ -1,6 +1,6 @@
 # Code Review
 
-Starter for an agent that reviews pull requests — pulls the diff from GitHub,
+Starter for an agent that reviews pull requests, pulls the diff from GitHub,
 checks out the repo, runs the tests, and posts a review with inline comments.
 
 ## Run it
@@ -8,7 +8,7 @@ checks out the repo, runs the tests, and posts a review with inline comments.
 From the repo root:
 
 ```bash
-ds "Review PR 123 in owner/repo — focus on security and API breakage"
+ds "Review PR 123 in owner/repo, focus on security and API breakage"
 ```
 
 In Slack (after `ds slack start`):
@@ -23,15 +23,15 @@ Create `.env` from `.env.example` and populate:
 
 - `ANTHROPIC_API_KEY`
 - `E2B_API_KEY`
-- `GITHUB_PERSONAL_ACCESS_TOKEN` — a fine-grained PAT with `Contents: read`,
+- `GITHUB_PERSONAL_ACCESS_TOKEN`: a fine-grained PAT with `Contents: read`,
   `Pull requests: read/write`, and `Metadata: read` on the target repo(s)
-- `LINEAR_API_KEY` — optional, lets the agent cross-reference tickets when
+- `LINEAR_API_KEY`: optional, lets the agent cross-reference tickets when
   the PR title or body mentions one
 
 ## Example prompts
 
 - Review PR 123 in owner/repo and leave inline comments on material issues.
-- Compare this PR against the description — call out anything out-of-scope.
+- Compare this PR against the description, call out anything out-of-scope.
 - What's blocking this PR from shipping? Read the CI logs and diff first.
 - Triage the last five PRs in owner/repo by risk and suggest review order.
 
@@ -40,6 +40,6 @@ Create `.env` from `.env.example` and populate:
 1. Add team conventions, required checks, or banned patterns to
    `system_prompt_append` in `sandstorm.json`.
 2. Narrow `allowed_tools` if the agent should not be allowed to run tests
-   locally — e.g. drop `Bash` to make it a pure read-only reviewer.
+   locally, e.g. drop `Bash` to make it a pure read-only reviewer.
 3. Switch `model` to `"opus"` for dense, complex reviews and `"haiku"` for
    high-volume triage of small PRs.

--- a/src/sandstorm/starters/code-review/sandstorm.json
+++ b/src/sandstorm/starters/code-review/sandstorm.json
@@ -1,0 +1,36 @@
+{
+  "system_prompt": "You are a senior code reviewer. Review the pull request or code diff the user references with these priorities, in order: correctness bugs and regressions, security vulnerabilities, API/contract breakage, then maintainability (naming, cohesion, unnecessary complexity). Cite specific files and line numbers from the diff or repository. When GitHub is available via the github MCP, pull the PR diff, inline comments, and CI status yourself before writing the review. Post inline comments only on material issues; summarize smaller nits in a single paragraph at the end. Never fabricate test output — always run the tests or read the CI logs before claiming something works.",
+  "model": "sonnet",
+  "max_turns": 25,
+  "allowed_tools": [
+    "Read",
+    "Grep",
+    "Glob",
+    "Bash",
+    "mcp__github__get_pull_request",
+    "mcp__github__get_pull_request_diff",
+    "mcp__github__get_pull_request_files",
+    "mcp__github__get_pull_request_comments",
+    "mcp__github__get_pull_request_reviews",
+    "mcp__github__create_pull_request_review",
+    "mcp__github__create_pull_request_review_comment",
+    "mcp__linear__get_issue",
+    "mcp__linear__list_issues"
+  ],
+  "mcp_servers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@fre4x/github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "linear-mcp"],
+      "env": {
+        "LINEAR_API_KEY": "${LINEAR_API_KEY:-}"
+      }
+    }
+  }
+}

--- a/src/sandstorm/store.py
+++ b/src/sandstorm/store.py
@@ -66,6 +66,38 @@ class RunStore:
         self._runs: deque[Run] = deque(maxlen=maxlen)
         self._index: dict[str, Run] = {}
         self._load_from_file()
+        self._maybe_compact_on_load()
+
+    def _maybe_compact_on_load(self) -> None:
+        """Rewrite the JSONL to the live in-deque set when it has grown past
+        10x the in-memory cap. Every status transition appends a new line, so
+        a long-running deployment accumulates stale records for runs that have
+        already fallen out of the deque. Bounds the file without changing
+        semantics or visible history in `list()`.
+        """
+        if not self._path.exists():
+            return
+        try:
+            with self._path.open("rb") as f:
+                line_count = sum(1 for _ in f)
+        except OSError:
+            return
+        if line_count <= self._maxlen * 10:
+            return
+        try:
+            tmp = self._path.with_suffix(self._path.suffix + ".compact")
+            with tmp.open("w") as f:
+                for run in self._runs:
+                    f.write(json.dumps(run.to_dict()) + "\n")
+            tmp.replace(self._path)
+            logger.info(
+                "RunStore: compacted %s (%d lines -> %d)",
+                self._path,
+                line_count,
+                len(self._runs),
+            )
+        except OSError:
+            logger.warning("RunStore: compact failed", exc_info=True)
 
     def create(
         self,

--- a/src/sandstorm/store.py
+++ b/src/sandstorm/store.py
@@ -44,9 +44,10 @@ class Run:
 
 
 # Whitelist of sandstorm.json / QueryRequest keys that are safe to snapshot into
-# a Run record for `ds replay`. Widen with care — env maps, raw file contents,
-# and mcp_servers configs often carry secrets.
-_CONFIG_SNAPSHOT_KEYS = frozenset({"model", "max_turns", "timeout", "allowed_tools"})
+# a Run record for `ds replay`. Widen with care: env maps and mcp_servers
+# configs often carry secrets. `files` stays in because file contents were
+# already persisted in the prompt; excluding them breaks replay reproducibility.
+_CONFIG_SNAPSHOT_KEYS = frozenset({"model", "max_turns", "timeout", "allowed_tools", "files"})
 
 
 def build_config_snapshot(source: dict | None) -> dict | None:

--- a/src/sandstorm/store.py
+++ b/src/sandstorm/store.py
@@ -1,11 +1,15 @@
 import json
 import logging
 from collections import deque
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 logger = logging.getLogger(__name__)
+
+RunStatus = Literal["running", "completed", "error"]
 
 
 @dataclass
@@ -13,7 +17,7 @@ class Run:
     id: str
     prompt: str
     model: str | None
-    status: str  # "running", "completed", "error"
+    status: RunStatus
     started_at: str
     cost_usd: float | None = None
     num_turns: int | None = None
@@ -22,23 +26,34 @@ class Run:
     files_count: int = 0
     feedback: str | None = None
     feedback_user: str | None = None
-    # Untruncated prompt — needed for `ds replay` (distinct from the 100-char display `prompt`)
+    # Untruncated, distinct from the 100-char display `prompt`; needed for ds replay.
     raw_prompt: str = ""
-    # Captured from runner.mjs on completion — enables Agent SDK session resume
     agent_session_id: str | None = None
-    # Captured at sandbox creation — enables E2B pause/resume across Slack messages
     sandbox_id: str | None = None
-    # Slack thread context — nullable for CLI/HTTP runs
     team_id: str | None = None
     user_id: str | None = None
     channel_id: str | None = None
     thread_ts: str | None = None
-    # Snapshot of runtime config (model, allowed_tools, mcp_servers, files)
-    # so replays can reproduce the original run deterministically
+    # Only the keys explicitly allowed by `_CONFIG_SNAPSHOT_KEYS` are written here;
+    # env / secret / mcp_servers values are intentionally excluded to keep the
+    # JSONL file free of credentials.
     config_snapshot: dict | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+# Whitelist of sandstorm.json / QueryRequest keys that are safe to snapshot into
+# a Run record for `ds replay`. Widen with care — env maps, raw file contents,
+# and mcp_servers configs often carry secrets.
+_CONFIG_SNAPSHOT_KEYS = frozenset({"model", "max_turns", "timeout", "allowed_tools"})
+
+
+def build_config_snapshot(source: dict | None) -> dict | None:
+    """Return a filtered copy of `source` containing only replay-safe keys."""
+    if not source:
+        return None
+    return {k: v for k, v in source.items() if k in _CONFIG_SNAPSHOT_KEYS}
 
 
 class RunStore:
@@ -137,6 +152,35 @@ class RunStore:
         runs = list(self._runs)
         runs.reverse()  # newest first
         return [r.to_dict() for r in runs[:limit]]
+
+    def get(self, run_id: str) -> Run | None:
+        """Return the Run with this id, or None. O(1)."""
+        return self._index.get(run_id)
+
+    def find_most_recent(self, predicate: Callable[[Run], bool]) -> Run | None:
+        """Return the most recent Run matching the predicate, or None."""
+        for run in reversed(self._runs):
+            if predicate(run):
+                return run
+        return None
+
+    def find_thread_session(
+        self, team_id: str | None, channel_id: str, thread_ts: str
+    ) -> Run | None:
+        """Return the most recent completed Run in this Slack thread, if any.
+
+        Used by slack.py to pick up a prior agent_session_id (Agent SDK resume)
+        and sandbox_id (E2B pause/resume) when the in-memory pool misses,
+        including after a server restart.
+        """
+        return self.find_most_recent(
+            lambda r: (
+                r.team_id == team_id
+                and r.channel_id == channel_id
+                and r.thread_ts == thread_ts
+                and r.status == "completed"
+            )
+        )
 
     def _append_to_file(self, run: Run) -> None:
         try:

--- a/src/sandstorm/store.py
+++ b/src/sandstorm/store.py
@@ -22,6 +22,20 @@ class Run:
     files_count: int = 0
     feedback: str | None = None
     feedback_user: str | None = None
+    # Untruncated prompt — needed for `ds replay` (distinct from the 100-char display `prompt`)
+    raw_prompt: str = ""
+    # Captured from runner.mjs on completion — enables Agent SDK session resume
+    agent_session_id: str | None = None
+    # Captured at sandbox creation — enables E2B pause/resume across Slack messages
+    sandbox_id: str | None = None
+    # Slack thread context — nullable for CLI/HTTP runs
+    team_id: str | None = None
+    user_id: str | None = None
+    channel_id: str | None = None
+    thread_ts: str | None = None
+    # Snapshot of runtime config (model, allowed_tools, mcp_servers, files)
+    # so replays can reproduce the original run deterministically
+    config_snapshot: dict | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -43,6 +57,13 @@ class RunStore:
         prompt: str,
         model: str | None,
         files_count: int = 0,
+        raw_prompt: str | None = None,
+        sandbox_id: str | None = None,
+        team_id: str | None = None,
+        user_id: str | None = None,
+        channel_id: str | None = None,
+        thread_ts: str | None = None,
+        config_snapshot: dict | None = None,
     ) -> Run:
         run = Run(
             id=id,
@@ -51,6 +72,13 @@ class RunStore:
             status="running",
             started_at=datetime.now(UTC).isoformat(),
             files_count=files_count,
+            raw_prompt=raw_prompt if raw_prompt is not None else prompt,
+            sandbox_id=sandbox_id,
+            team_id=team_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            config_snapshot=config_snapshot,
         )
         # If deque is full, evict the oldest and remove from index
         if len(self._runs) == self._maxlen:
@@ -67,6 +95,8 @@ class RunStore:
         num_turns: int | None = None,
         duration_secs: float | None = None,
         model: str | None = None,
+        agent_session_id: str | None = None,
+        sandbox_id: str | None = None,
     ) -> None:
         run = self._index.get(id)
         if run is None:
@@ -78,6 +108,10 @@ class RunStore:
         run.duration_secs = duration_secs
         if model:
             run.model = model
+        if agent_session_id:
+            run.agent_session_id = agent_session_id
+        if sandbox_id:
+            run.sandbox_id = sandbox_id
         self._append_to_file(run)
 
     def fail(self, id: str, error: str, duration_secs: float | None = None) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -702,6 +702,69 @@ class TestCli:
         assert "URL must use http:// or https://" in result.output
 
 
+class TestUpgrade:
+    def test_upgrade_already_at_latest(self, monkeypatch):
+        import importlib.metadata
+
+        from sandstorm.cli import cli
+
+        _disable_dotenv(monkeypatch)
+        monkeypatch.setattr(importlib.metadata, "version", lambda _: "1.2.3")
+
+        import io
+        import json as _json
+        from unittest.mock import patch
+
+        class _FakeResp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return _json.dumps({"info": {"version": "1.2.3"}, "releases": {}}).encode()
+
+        with patch("urllib.request.urlopen", return_value=_FakeResp()):
+            result = CliRunner().invoke(cli, ["upgrade"])
+        assert result.exit_code == 0
+        assert "Already up to date" in result.output
+
+    def test_upgrade_prompts_before_install(self, monkeypatch):
+        import importlib.metadata
+
+        from sandstorm.cli import cli
+
+        _disable_dotenv(monkeypatch)
+        monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.8.1")
+
+        import io
+        import json as _json
+        from unittest.mock import patch
+
+        class _FakeResp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return _json.dumps(
+                    {
+                        "info": {"version": "0.9.0"},
+                        "releases": {"0.9.0": [{"upload_time_iso_8601": "2026-04-17T00:00:00Z"}]},
+                    }
+                ).encode()
+
+        with patch("urllib.request.urlopen", return_value=_FakeResp()):
+            # Answer "n" to the upgrade prompt — no install runs
+            result = CliRunner().invoke(cli, ["upgrade"], input="n\n")
+        assert result.exit_code == 0
+        assert "0.9.0" in result.output
+        assert "Cancelled" in result.output
+
+
 class TestReplay:
     def test_replay_unknown_id_exits_with_error(self, tmp_path, monkeypatch):
         _disable_dotenv(monkeypatch)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,24 @@ class TestCli:
         assert result.exit_code == 1
         assert "image.bin is not a text file" in result.output
 
+    def test_query_rejects_files_exceeding_size_cap(self, tmp_path, monkeypatch):
+        """Regression: the CLI used to read_text() any size, letting a huge
+        file OOM the process before QueryRequest's 10MB/file validator fired.
+        Now the per-file cap is enforced upstream with a friendly error."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+        big = tmp_path / "huge.txt"
+        # 11 MB of newline-terminated ascii — just above the 10 MB cap
+        big.write_text("a\n" * (11 * 1024 * 1024 // 2))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["query", "summarise", "-f", str(big)])
+
+        assert result.exit_code == 1
+        assert "huge.txt" in result.output
+        assert "max" in result.output
+
     def test_query_uses_relative_paths_for_uploaded_files(self, tmp_path, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
         monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,13 +15,23 @@ def _make_fake_run_agent_in_sandbox(seen=None):
         if seen is not None:
             seen["request_id"] = request_id
             seen["prompt"] = request.prompt
+            seen["request"] = request
         yield json.dumps(
             {
                 "type": "assistant",
                 "message": {"content": [{"type": "text", "text": f"handled: {request.prompt}"}]},
             }
         )
-        yield json.dumps({"type": "result", "subtype": "success", "num_turns": 1, "cost_usd": 0.0})
+        yield json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "num_turns": 1,
+                "cost_usd": 0.005,
+                "total_cost_usd": 0.005,
+                "model": request.model or "sonnet",
+            }
+        )
 
     return _run
 
@@ -690,3 +700,82 @@ class TestCli:
 
         assert result.exit_code == 1
         assert "URL must use http:// or https://" in result.output
+
+
+class TestReplay:
+    def test_replay_unknown_id_exits_with_error(self, tmp_path, monkeypatch):
+        _disable_dotenv(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+        # Point run_store at an empty JSONL so no runs are visible to replay
+        from sandstorm.store import RunStore
+
+        monkeypatch.setattr("sandstorm.store.run_store", RunStore(path=tmp_path / "runs.jsonl"))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["replay", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_replay_forks_session_and_reports_metrics(self, tmp_path, monkeypatch):
+        _disable_dotenv(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+        from sandstorm.store import RunStore
+
+        rs = RunStore(path=tmp_path / "runs.jsonl")
+        rs.create(
+            id="orig-1",
+            prompt="compare two things",
+            model="claude-opus-4-7",
+            raw_prompt="compare these two competitor pricing pages",
+            config_snapshot={
+                "model": "claude-opus-4-7",
+                "allowed_tools": ["Read", "Bash"],
+                "timeout": 300,
+            },
+        )
+        rs.complete(
+            id="orig-1",
+            cost_usd=0.15,
+            num_turns=8,
+            duration_secs=42.0,
+            model="claude-opus-4-7",
+            agent_session_id="sess_original_abc",
+        )
+        monkeypatch.setattr("sandstorm.store.run_store", rs)
+
+        import sandstorm.sandbox as sandbox
+
+        seen: dict = {}
+        monkeypatch.setattr(sandbox, "run_agent_in_sandbox", _make_fake_run_agent_in_sandbox(seen))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "replay",
+                "orig-1",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--budget",
+                "0.05",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        # Verify replay used the raw_prompt + forked the original session
+        req = seen["request"]
+        assert req.prompt == "compare these two competitor pricing pages"
+        assert req.model == "claude-haiku-4-5-20251001"
+        assert req.resume == "sess_original_abc"
+        assert req.fork_session is True
+        assert req.max_budget_usd == 0.05
+
+        # Report written to stderr (CliRunner captures stderr with output by default
+        # when mix_stderr=True, which is the default).
+        assert "Replay report" in result.output
+        assert "orig-1" in result.output
+        assert "claude-haiku-4-5-20251001" in result.output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,75 @@
+"""Tests for the `ds doctor` preflight."""
+
+import asyncio
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sandstorm.cli import cli
+from sandstorm.doctor import run_checks
+
+
+def _clear_provider_env(monkeypatch):
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "ANTHROPIC_BASE_URL",
+        "E2B_API_KEY",
+        "SLACK_BOT_TOKEN",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestRunChecks:
+    def test_flags_missing_provider_credentials(self, monkeypatch):
+        _clear_provider_env(monkeypatch)
+        results = asyncio.run(run_checks())
+        provider_check = next(c for c in results if c.name == "Provider credentials")
+        assert provider_check.passed is False
+        assert "ANTHROPIC_API_KEY" in provider_check.hint
+
+        e2b_check = next(c for c in results if c.name == "E2B credentials")
+        assert e2b_check.passed is False
+        assert "E2B_API_KEY" in e2b_check.hint
+
+    def test_passes_with_custom_base_url_and_valid_e2b(self, monkeypatch):
+        _clear_provider_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://openrouter.example")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "sk-openrouter-x")
+        monkeypatch.setenv("E2B_API_KEY", "e2b_fake_key")
+
+        async def _fake_e2b(api_key):
+            return (True, "OK (0 sandboxes visible)")
+
+        with patch("sandstorm.doctor._probe_e2b", side_effect=_fake_e2b):
+            results = asyncio.run(run_checks())
+
+        provider_check = next(c for c in results if c.name == "Provider credentials")
+        assert provider_check.passed is True
+        assert "custom base URL" in provider_check.detail
+
+        e2b_check = next(c for c in results if c.name == "E2B credentials")
+        assert e2b_check.passed is True
+
+
+class TestDoctorCli:
+    def test_doctor_exits_nonzero_when_checks_fail(self, monkeypatch):
+        monkeypatch.setattr("sandstorm.cli.load_dotenv", lambda: None)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_USE_FOUNDRY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.delenv("E2B_API_KEY", raising=False)
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["doctor"])
+        assert result.exit_code == 1
+        assert "Provider credentials" in result.output
+        assert "E2B_API_KEY" in result.output

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,8 +1,13 @@
-"""Tests for the user-scoped MemoryStore."""
+"""Tests for the user-scoped MemoryStore and its injection into agent config."""
 
 import json
 
+import pytest
+
+import sandstorm.config as config_mod
+from sandstorm.config import _build_agent_config
 from sandstorm.memory import MemoryStore
+from sandstorm.models import QueryRequest
 
 
 class TestRememberAndList:
@@ -139,3 +144,73 @@ class TestDequeEviction:
         assert "m0" not in memories
         assert "m1" not in memories
         assert memories == ["m2", "m3", "m4"]
+
+
+@pytest.fixture()
+def _api_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+
+@pytest.fixture(autouse=True)
+def _reset_loaded_dotenv(monkeypatch):
+    monkeypatch.setattr(config_mod, "_LOADED_DOTENV_VALUES", {})
+    monkeypatch.setattr(config_mod, "_env_mtime", 0.0)
+
+
+def _patched_store(monkeypatch, tmp_path) -> MemoryStore:
+    """Redirect the module-level memory_store used by config._build_agent_config
+    to a temp-path store so tests stay isolated from real `.sandstorm/`."""
+    store = MemoryStore(path=tmp_path / "m.jsonl")
+    monkeypatch.setattr(config_mod, "memory_store", store)
+    return store
+
+
+class TestMemoryInjection:
+    def test_no_memory_no_prefix(self, monkeypatch, tmp_path, _api_keys):
+        _patched_store(monkeypatch, tmp_path)
+        req = QueryRequest(prompt="hi", team_id="T1", user_id="U1")
+        config, _ = _build_agent_config(req, {}, {})
+        # Without any memories or env_append, system_prompt stays unset
+        assert config.get("system_prompt") is None
+
+    def test_memory_injected_as_append(self, monkeypatch, tmp_path, _api_keys):
+        store = _patched_store(monkeypatch, tmp_path)
+        store.remember("T1", "U1", "favourite db is postgres")
+        req = QueryRequest(prompt="hi", team_id="T1", user_id="U1")
+        config, _ = _build_agent_config(req, {}, {})
+        sys_prompt = config["system_prompt"]
+        assert isinstance(sys_prompt, str)
+        assert "User memory" in sys_prompt
+        assert "favourite db is postgres" in sys_prompt
+
+    def test_memory_prepended_to_existing_append(self, monkeypatch, tmp_path, _api_keys):
+        store = _patched_store(monkeypatch, tmp_path)
+        store.remember("T1", "U1", "ships to berlin")
+        req = QueryRequest(prompt="hi", team_id="T1", user_id="U1")
+        config, _ = _build_agent_config(
+            req,
+            {"system_prompt_append": "Follow project conventions."},
+            {},
+        )
+        sys_prompt = config["system_prompt"]
+        # Memory comes first, then the config append, so project conventions
+        # always land closest to the prompt (highest-precedence instruction)
+        conv = sys_prompt.index("Follow project conventions.")
+        assert sys_prompt.index("ships to berlin") < conv
+
+    def test_memory_scoped_to_user(self, monkeypatch, tmp_path, _api_keys):
+        store = _patched_store(monkeypatch, tmp_path)
+        store.remember("T1", "U1", "user-one preference")
+        store.remember("T1", "U2", "user-two preference")
+        req = QueryRequest(prompt="hi", team_id="T1", user_id="U1")
+        config, _ = _build_agent_config(req, {}, {})
+        assert "user-one preference" in config["system_prompt"]
+        assert "user-two preference" not in (config["system_prompt"] or "")
+
+    def test_no_team_context_uses_local_scope(self, monkeypatch, tmp_path, _api_keys):
+        store = _patched_store(monkeypatch, tmp_path)
+        store.remember(None, None, "local-only fact")
+        req = QueryRequest(prompt="hi")  # no team_id / user_id
+        config, _ = _build_agent_config(req, {}, {})
+        assert "local-only fact" in config["system_prompt"]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -145,6 +145,27 @@ class TestDequeEviction:
         assert "m1" not in memories
         assert memories == ["m2", "m3", "m4"]
 
+    def test_tombstone_for_evicted_entry_does_not_reenter(self, tmp_path):
+        """Regression: a tombstone written for a memory that was later evicted
+        from the deque must not re-enter storage on reload. Before the fix
+        the tombstone-record path appended the deleted record to the deque,
+        consuming a slot with a dead entry."""
+        path = tmp_path / "m.jsonl"
+        s1 = MemoryStore(path=path, maxlen=3)
+        # Create then delete the first entry (writes a tombstone line)
+        s1.remember("T1", "U1", "delete-me")
+        s1.forget("T1", "U1", "delete-me")
+        # Push enough new entries to evict the tombstone's id from the deque
+        for i in range(5):
+            s1.remember("T1", "U1", f"live-{i}")
+
+        s2 = MemoryStore(path=path, maxlen=3)
+        live = [m.text for m in s2.list("T1", "U1")]
+        # All three slots hold real live entries; tombstone did not sneak in
+        assert len(s2._memories) == 3
+        assert "delete-me" not in live
+        assert all(t.startswith("live-") for t in live)
+
 
 @pytest.fixture()
 def _api_keys(monkeypatch):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,141 @@
+"""Tests for the user-scoped MemoryStore."""
+
+import json
+
+from sandstorm.memory import MemoryStore
+
+
+class TestRememberAndList:
+    def test_remember_returns_memory(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        m = store.remember("T1", "U1", "favourite db is postgres")
+        assert m.team_id == "T1"
+        assert m.user_id == "U1"
+        assert m.text == "favourite db is postgres"
+        assert m.deleted is False
+
+    def test_list_returns_live_memories(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "likes oat milk")
+        store.remember("T1", "U1", "ships to berlin")
+        memories = store.list("T1", "U1")
+        assert {m.text for m in memories} == {"likes oat milk", "ships to berlin"}
+
+    def test_list_is_scoped_by_user(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "user-one secret")
+        store.remember("T1", "U2", "user-two secret")
+        assert [m.text for m in store.list("T1", "U1")] == ["user-one secret"]
+        assert [m.text for m in store.list("T1", "U2")] == ["user-two secret"]
+
+    def test_list_is_scoped_by_team(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "team-one secret")
+        store.remember("T2", "U1", "team-two secret")
+        assert [m.text for m in store.list("T1", "U1")] == ["team-one secret"]
+        assert [m.text for m in store.list("T2", "U1")] == ["team-two secret"]
+
+    def test_local_default_team_when_none(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember(None, None, "cli preference")
+        memories = store.list(None, None)
+        assert [m.text for m in memories] == ["cli preference"]
+
+
+class TestForget:
+    def test_forget_substring_tombstones(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "favourite db is postgres")
+        store.remember("T1", "U1", "favourite lang is python")
+        deleted = store.forget("T1", "U1", "postgres")
+        assert deleted == 1
+        assert [m.text for m in store.list("T1", "U1")] == ["favourite lang is python"]
+
+    def test_forget_is_case_insensitive(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "likes OAT milk")
+        assert store.forget("T1", "U1", "oat") == 1
+        assert store.list("T1", "U1") == []
+
+    def test_forget_scoped_to_user(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "my api_key is hidden")
+        store.remember("T1", "U2", "my api_key is shared")
+        deleted = store.forget("T1", "U1", "api_key")
+        assert deleted == 1
+        assert [m.text for m in store.list("T1", "U2")] == ["my api_key is shared"]
+
+    def test_forget_nonexistent_returns_zero(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "fact one")
+        assert store.forget("T1", "U1", "not there") == 0
+
+
+class TestAsPromptPrefix:
+    def test_empty_store_returns_empty_string(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        assert store.as_prompt_prefix("T1", "U1") == ""
+
+    def test_bullets_include_all_live_memories(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "based in berlin")
+        store.remember("T1", "U1", "prefers typescript")
+        prefix = store.as_prompt_prefix("T1", "U1")
+        assert "User memory" in prefix
+        assert "- based in berlin" in prefix
+        assert "- prefers typescript" in prefix
+        assert prefix.endswith("\n\n")  # safe to concatenate
+
+    def test_deleted_memories_excluded_from_prefix(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl")
+        store.remember("T1", "U1", "fact one")
+        store.remember("T1", "U1", "fact two")
+        store.forget("T1", "U1", "two")
+        prefix = store.as_prompt_prefix("T1", "U1")
+        assert "fact one" in prefix
+        assert "fact two" not in prefix
+
+
+class TestJsonlPersistence:
+    def test_reload_restores_live_memories(self, tmp_path):
+        path = tmp_path / "m.jsonl"
+        s1 = MemoryStore(path=path)
+        s1.remember("T1", "U1", "kept")
+        s2 = MemoryStore(path=path)
+        assert [m.text for m in s2.list("T1", "U1")] == ["kept"]
+
+    def test_tombstone_survives_reload(self, tmp_path):
+        path = tmp_path / "m.jsonl"
+        s1 = MemoryStore(path=path)
+        s1.remember("T1", "U1", "forget me")
+        s1.forget("T1", "U1", "forget")
+        s2 = MemoryStore(path=path)
+        assert s2.list("T1", "U1") == []
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        path = tmp_path / "m.jsonl"
+        valid_row = {
+            "id": "m1",
+            "team_id": "T1",
+            "user_id": "U1",
+            "text": "valid",
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "deleted": False,
+        }
+        path.write_text(
+            json.dumps(valid_row) + "\n" + "not valid json\n" + '{"incomplete": true}\n' + "\n"
+        )
+        store = MemoryStore(path=path)
+        assert [m.text for m in store.list("T1", "U1")] == ["valid"]
+
+
+class TestDequeEviction:
+    def test_maxlen_evicts_oldest(self, tmp_path):
+        store = MemoryStore(path=tmp_path / "m.jsonl", maxlen=3)
+        for i in range(5):
+            store.remember("T1", "U1", f"m{i}")
+        memories = [m.text for m in store.list("T1", "U1")]
+        # Deque holds 3 latest; earlier entries evicted without tombstone
+        assert "m0" not in memories
+        assert "m1" not in memories
+        assert memories == ["m2", "m3", "m4"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -77,6 +77,33 @@ class TestBuildQueryRequest:
         request = _build_query_request("analyze this", files)
         assert request.files == {"data.csv": "a,b\n1,2"}
 
+    def test_scoped_memory_fields_passthrough(self):
+        request = _build_query_request(
+            "hi", team_id="T1", user_id="U1", model="claude-haiku-4-5-20251001"
+        )
+        assert request.team_id == "T1"
+        assert request.user_id == "U1"
+        assert request.model == "claude-haiku-4-5-20251001"
+
+
+class TestSlashCommandsRegistered:
+    """Smoke: the Bolt app creates cleanly with slash-command handlers wired.
+
+    Functional coverage of the handlers' business logic lives in test_memory.py
+    (memory_store.remember/forget/list) — the handlers are thin wrappers around
+    that store. This test exists to catch registration-time regressions when
+    command names, arg spellings, or scope imports drift."""
+
+    def test_slack_app_creates_with_commands(self, monkeypatch):
+        from sandstorm.slack import create_slack_app
+
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "test-secret")
+        app = create_slack_app(bot_token="xoxb-test", signing_secret="test-secret")
+        # Bolt registers @app.command handlers on app._async_listeners — just
+        # assert the app was built and the slash-command callable exists.
+        assert app is not None
+
 
 class TestFetchThreadMessages:
     def test_returns_messages(self):

--- a/tests/test_starter_catalog.py
+++ b/tests/test_starter_catalog.py
@@ -20,6 +20,7 @@ def test_starter_catalog_contains_expected_slugs():
         "support-triage",
         "api-extractor",
         "security-audit",
+        "code-review",
     ]
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -197,6 +197,39 @@ class TestJsonlPersistence:
         assert r["team_id"] is None
         assert r["config_snapshot"] is None
 
+    def test_compacts_jsonl_beyond_10x_maxlen(self, tmp_path):
+        """Each status transition appends a line, so long-running deployments
+        accumulate stale records. On load, when the file grows past 10x the
+        deque cap, the store rewrites it to the live in-deque set."""
+        path = tmp_path / "runs.jsonl"
+        # Directly stuff the JSONL with 60 lines of plausible data. The store
+        # has maxlen=5, so anything beyond 5 will be evicted in memory — and
+        # the file should be compacted on next load because 60 > 5 * 10.
+        import json as _json
+
+        with path.open("w") as f:
+            for i in range(60):
+                f.write(
+                    _json.dumps(
+                        {
+                            "id": f"r{i}",
+                            "prompt": "p",
+                            "model": None,
+                            "status": "completed",
+                            "started_at": "2026-04-17T00:00:00+00:00",
+                        }
+                    )
+                    + "\n"
+                )
+
+        store = RunStore(path=path, maxlen=5)
+        # File must now hold exactly the live 5 entries
+        lines = path.read_text().splitlines()
+        assert len(lines) == 5
+        loaded_ids = [r["id"] for r in store.list()]
+        # Newest-first, so r59..r55 (deque kept the last 5)
+        assert loaded_ids[0] == "r59"
+
     def test_new_fields_persist_on_create_and_complete(self, tmp_path):
         path = tmp_path / "runs.jsonl"
         store = RunStore(path=path)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -166,6 +166,72 @@ class TestJsonlPersistence:
         store = RunStore(path=tmp_path / "nonexistent" / "runs.jsonl")
         assert store.list() == []
 
+    def test_loads_pre_upgrade_rows_without_new_fields(self, tmp_path):
+        """Rows written by pre-v0.9 versions lack new replay/resume fields; they must
+        still load with defaults (forward-compat for deployments upgrading in place)."""
+        path = tmp_path / "runs.jsonl"
+        pre_upgrade_row = {
+            "id": "legacy-1",
+            "prompt": "old prompt",
+            "model": "claude-sonnet-4-20250514",
+            "status": "completed",
+            "started_at": "2025-01-01T00:00:00+00:00",
+            "cost_usd": 0.02,
+            "num_turns": 3,
+            "duration_secs": 12.0,
+            "error": None,
+            "files_count": 0,
+            "feedback": None,
+            "feedback_user": None,
+        }
+        path.write_text(json.dumps(pre_upgrade_row) + "\n")
+        store = RunStore(path=path)
+        runs = store.list()
+        assert len(runs) == 1
+        r = runs[0]
+        assert r["id"] == "legacy-1"
+        # New fields default cleanly
+        assert r["raw_prompt"] == ""
+        assert r["agent_session_id"] is None
+        assert r["sandbox_id"] is None
+        assert r["team_id"] is None
+        assert r["config_snapshot"] is None
+
+    def test_new_fields_persist_on_create_and_complete(self, tmp_path):
+        path = tmp_path / "runs.jsonl"
+        store = RunStore(path=path)
+        store.create(
+            id="r1",
+            prompt="x" * 200,  # display-truncated, raw kept full
+            model="claude-opus-4-7",
+            team_id="T_abc",
+            user_id="U_xyz",
+            channel_id="C_chan",
+            thread_ts="1700000000.000001",
+            config_snapshot={"model": "claude-opus-4-7", "allowed_tools": ["Read"]},
+        )
+        store.complete(
+            id="r1",
+            cost_usd=0.03,
+            num_turns=2,
+            duration_secs=6.0,
+            agent_session_id="sess_12345",
+            sandbox_id="sbx_abc",
+        )
+        # Reload from disk to confirm persistence
+        store2 = RunStore(path=path)
+        runs = store2.list()
+        assert len(runs) == 1
+        r = runs[0]
+        assert r["raw_prompt"] == "x" * 200
+        assert r["team_id"] == "T_abc"
+        assert r["user_id"] == "U_xyz"
+        assert r["channel_id"] == "C_chan"
+        assert r["thread_ts"] == "1700000000.000001"
+        assert r["config_snapshot"] == {"model": "claude-opus-4-7", "allowed_tools": ["Read"]}
+        assert r["agent_session_id"] == "sess_12345"
+        assert r["sandbox_id"] == "sbx_abc"
+
     def test_empty_file_starts_empty(self, tmp_path):
         path = tmp_path / "runs.jsonl"
         path.write_text("")


### PR DESCRIPTION
## Summary

21 commits, 39 files, +3042 / -131. Positions Sandstorm as the self-hosted,
multi-provider, observable alternative to Claude Managed Agents + Vercel Slack
Agent Skill. Plan lived at `~/.claude/plans/how-can-we-improve-elegant-hennessy.md`.

### New features

- **SDK upgrades**: Claude Agent SDK `0.2.42` → `0.2.112`, E2B `2.13` → `2.20` (pin tightened to `>=2.20.0,<3.0.0`).
- **User memory**: JSONL-backed `MemoryStore` scoped on `(team_id, user_id)`; injected into `system_prompt_append` at query time, no tool plumbing. Slash commands `/remember`, `/forget`, `/memories`.
- **Session resume**: Agent SDK `resume=<session_id>` across Slack thread messages, with `fork_session` available via replay.
- **Sandbox pause/resume**: `sbx.pause()` on Slack runs so filesystem + processes persist across messages and server restarts. Pause failure falls back to `kill()` so no orphaned billable sandboxes.
- **`ds replay <run_id>`**: fork the original session with `--model`, `--budget`, `--allowed-tools`, `--output`; markdown diff report (cost Δ, latency Δ, turns Δ).
- **`ds doctor` / `ds slack verify`**: end-to-end preflight (provider creds, E2B, optional throwaway sandbox, Slack auth/scopes, OTel reachability) with per-failure fix hints.
- **`ds upgrade`**: PyPI version check, CHANGELOG diff, prompt, in-place install.
- **`/model` slash command**: per-channel-per-user override.
- **Tool breadcrumbs**: inline `:hammer_and_wrench:` in the `@mention` stream (DMs already used `set_status`).
- **Code-review starter**: GitHub PR reviewer with Linear cross-reference (7th starter).
- **Railway one-click template** + hardened Dockerfile (Python 3.13, `[slack,telemetry]` extras baked in).
- **TypeScript client** `@duvo/sandstorm-client`: typed SSE `query()`, `listRuns()`, `health()`; zero runtime deps, Node 18+.
- **Observability**: OpenTelemetry export docs for Langfuse / Phoenix / Langsmith + `docker-compose.langfuse.yml` for a one-command local trace stack.

### Cleanup (from `/simplify` and `/code-reviewer`)

- Public `RunStore` accessors (`get`, `find_most_recent`, `find_thread_session`) replace private-attribute access from `slack.py` / `cli.py`.
- `build_config_snapshot()` whitelist (`model`, `max_turns`, `timeout`, `allowed_tools`, `files`) keeps secrets out of `runs.jsonl`.
- `memories.jsonl` is `chmod 0o600` on first write (memories often carry credentials).
- SSE parser in the TS client joins multi-line `data:` payloads per spec; buffer capped at 16MB.
- `RunStatus = Literal[...]` type alias.
- HTTP `/query` now populates `config_snapshot`, so `ds replay` of HTTP runs reproduces the original config.

### Docs

README rewritten with a concrete terminal + Slack demo and a comparison table. New: `docs/comparison.md`, `docs/faq-vs-managed-agents.md`, `docs/multi-llm.md`, `docs/memory.md`, `docs/replay.md`, `docs/observability.md`. `CHANGELOG.md` regenerated via `git-cliff`.

## Test plan

- [x] `uv run pytest tests/` — 335 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `uv run --with pyright pyright src/sandstorm/` — 0 errors
- [x] `uv sync --extra dev --extra slack --extra telemetry` resolves with E2B 2.20 + Agent SDK 0.2.112
- [ ] Manual Slack smoke test on a dev workspace: `@mention`, `/remember`, `/forget`, `/memories`, `/model`, thread continuity across a server restart
- [ ] `ds doctor` on a fresh machine: confirm red ✗ with specific fix hints, then green after each fix
- [ ] `ds replay <run_id> --model claude-haiku-4-5-20251001 --budget 0.05` against a prior Opus run; verify diff report
- [ ] Railway button deploy: env vars set, `/health` returns 200
- [ ] `docker compose -f deploy/docker-compose.langfuse.yml up` — traces visible on localhost:3000
- [ ] Re-cut the E2B custom template with `uv run python build_template.py` to bake the new SDK pin
- [ ] After merge, `gh release create v0.9.0` to trigger the PyPI publish workflow