### PR TITLE
fix(ci): skip-existing on pypi publish for retryability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
       - run: uv build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   publish-npm:
     name: Build & Publish (npm)


### PR DESCRIPTION
Lets the publish workflow be re-run after a transient failure (e.g. the npm lockfile issue we hit on v0.9.1) without needing a version bump.