### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Sandstorm will be documented in this file.
 
+## [0.9.2] - 2026-04-17
+
+### Bug Fixes
+
+- ci: add package-lock.json so npm publish workflow can run (#50)
+- ci: pypi publish skip-existing for release retryability (#51)
+
+No user-facing changes. v0.9.2 exists because v0.9.1's GitHub release
+was locked immutable before the publish workflow finished; this tag
+re-runs the workflow so `@duvo/sandstorm-client@0.9.2` lands on npm
+alongside `duvo-sandstorm==0.9.2` on PyPI. Code content identical to
+v0.9.1.
+
 ## [0.9.1] - 2026-04-17
 
 ### Bug Fixes

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@duvo/sandstorm-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@duvo/sandstorm-client",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duvo/sandstorm-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "TypeScript client for the Sandstorm agent runtime — stream agent runs, manage memory, replay past runs.",
   "license": "MIT",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duvo-sandstorm"
-version = "0.9.1"
+version = "0.9.2"
 description = "Open-source runtime for general-purpose AI agents in isolated sandboxes."
 keywords = ["ai-agents", "anthropic", "claude", "e2b", "fastapi", "openrouter", "sandbox", "slack"]
 readme = "README.md"


### PR DESCRIPTION
Re-ships v0.9.1 content because GitHub's immutable-release rule locked the v0.9.1 tag before npm could publish. v0.9.2 lets the publish workflow complete end-to-end.