### PR TITLE
docs: document runtime provider and local TypeScript client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI + npm
+name: Publish to PyPI
 
 on:
   release:
@@ -20,22 +20,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
-
-  publish-npm:
-    name: Build & Publish (npm)
-    runs-on: ubuntu-latest
-    needs: publish-pypi
-    defaults:
-      run:
-        working-directory: clients/typescript
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: https://registry.npmjs.org
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Sandstorm will be documented in this file.
 
+## [Unreleased]
+
+### Documentation
+
+- document runtime provider and local TypeScript client
+
 ## [0.9.2] - 2026-04-17
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Claude Agent SDK, or any LLM, as a sandboxed agent in your Slack, on your infra.**
 
-CLI, HTTP API, Python client, Slack bot, and TypeScript client over the same runtime.
-Fresh E2B sandbox per thread, streaming, file uploads, replay, and OpenTelemetry traces
-out of the box.
+CLI, HTTP API, Python client, Slack bot, and repo-local TypeScript client source over
+the same runtime. Fresh sandbox per thread on the configured runtime, E2B by default,
+with streaming, file uploads, replay, and OpenTelemetry traces out of the box.
 
 [![CI](https://github.com/tomascupr/sandstorm/actions/workflows/ci.yml/badge.svg)](https://github.com/tomascupr/sandstorm/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/duvo-sandstorm.svg)](https://pypi.org/project/duvo-sandstorm/)
@@ -67,7 +67,8 @@ bot:       (paused thread sandbox resumed)
 ## Three things only OSS can do
 
 1. **Self-host**: runs on your Railway/Fly/K8s/Docker. Data stays in your network.
-   E2B is available self-hosted; Anthropic's Managed Agents are Anthropic-infra only.
+   The default E2B runtime is available self-hosted; Anthropic's Managed Agents are
+   Anthropic-infra only.
 2. **Every LLM**: Anthropic direct, OpenRouter (GPT-5, Gemini, DeepSeek, Qwen, Kimi,
    Grok), Vertex AI, Bedrock, Azure Foundry, any OpenAI-compatible base URL.
 3. **Your observability**: OTel export to [Langfuse](docs/observability.md),
@@ -83,7 +84,7 @@ bot:       (paused thread sandbox resumed)
 | Multi-provider (not just Claude) | ✅   |           ❌           |             ✅            |           ❌           |
 | OTel traces to any backend |     ✅     |           ❌           |             ❌            |           ❌           |
 | OSS license                |   MIT     |        Proprietary    |        Apache templates  |          MIT          |
-| Ships a TypeScript client  |     ✅     |           ✅           |             ✅            |           ❌           |
+| Runtime client source in repo | ✅  |           ❌           |             ✅            |           ❌           |
 | Session resume + replay    |     ✅     |           ✅           |             ❌            |           ❌           |
 
 Full side-by-side in [docs/comparison.md](docs/comparison.md);
@@ -121,9 +122,9 @@ Once installed:
 - Reaction triggers: add an emoji to any message to fire an agent (v0.9.1, see [docs/triggers.md](docs/triggers.md))
 - App Home tab shows memories, active runs, channel defaults, and triggers (v0.9.1)
 
-Thread continuity is real: each thread keeps its own paused E2B sandbox, so uploaded files,
-generated outputs, and installed packages survive across messages, even across server restarts.
-See [docs/memory.md](docs/memory.md).
+Thread continuity is real: each thread keeps its own paused sandbox on the configured runtime,
+E2B by default, so uploaded files, generated outputs, and installed packages survive across
+messages, even across server restarts. See [docs/memory.md](docs/memory.md).
 
 ## Triggers (v0.9.1)
 
@@ -196,7 +197,8 @@ pip install "duvo-sandstorm[slack]"           # Slack bot
 pip install "duvo-sandstorm[telemetry]"       # OpenTelemetry
 ```
 
-TypeScript client: `npm install @duvo/sandstorm-client` (see [clients/typescript](clients/typescript)).
+TypeScript client source lives in [clients/typescript](clients/typescript/README.md) for
+repo-local workspace usage. It is not published to npm.
 
 ## Deploy
 
@@ -215,7 +217,7 @@ TypeScript client: `npm install @duvo/sandstorm-client` (see [clients/typescript
 - [Memory: `/remember`, `/forget`, persistence guarantees](docs/memory.md)
 - [Replay](docs/replay.md)
 - [Python client](docs/client.md) · [TypeScript client](clients/typescript/README.md)
-- [Configuration](docs/config.md) · [API reference](docs/api.md)
+- [Configuration](docs/configuration.md) · [API reference](docs/api.md)
 - [Slack bot](docs/slack.md) · [Deployment](docs/deployment.md) · [OpenRouter](docs/openrouter.md)
 
 ## Community

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,23 +1,30 @@
-# @duvo/sandstorm-client
+# Sandstorm TypeScript client source
 
-Thin TypeScript client for the [Sandstorm](https://github.com/tomascupr/sandstorm)
-agent runtime, stream agent runs over SSE, list prior runs, check health.
-Zero runtime dependencies (uses global `fetch`).
+Thin repo-local TypeScript client source for the [Sandstorm](https://github.com/tomascupr/sandstorm)
+agent runtime: stream agent runs over SSE, list prior runs, and check health. Zero runtime
+dependencies (uses global `fetch`).
 
-## Install
+This package is private and intended for source/workspace usage from this repository. It is
+not published to npm.
+
+Requires Node 18+ or any runtime with a global `fetch`.
+
+## Local usage
 
 ```bash
-npm install @duvo/sandstorm-client
-# or
-pnpm add @duvo/sandstorm-client
+cd clients/typescript
+npm install
+npm run build
+ds serve
+npm exec -- tsx examples/chat.ts "your prompt here"
 ```
-
-Requires Node 18+ (or any runtime with a global `fetch`).
 
 ## Quick start
 
+From code inside `clients/typescript`, import the source entry point directly:
+
 ```ts
-import { SandstormClient } from "@duvo/sandstorm-client";
+import { SandstormClient } from "./src/index.js";
 
 const client = new SandstormClient({
   baseUrl: "http://localhost:8000",
@@ -61,12 +68,12 @@ Mirrors `GET /health`.
 
 ## Types
 
-All request and response types are re-exported from the entry point 
+All request and response types are re-exported from the entry point
 `QueryRequest`, `Run`, `SSEEvent`, `HealthResponse`, `ClientOptions`.
 
 ## Examples
 
-See `examples/chat.ts` for a minimal CLI-style example.
+See `examples/chat.ts` for a minimal CLI-style example that runs from this workspace.
 
 ## License
 

--- a/clients/typescript/examples/chat.ts
+++ b/clients/typescript/examples/chat.ts
@@ -2,8 +2,8 @@
  * Minimal CLI example. Run against a local `ds serve`:
  *
  *   ds serve                           # in one terminal
- *   pnpm install
- *   pnpm tsx examples/chat.ts "your prompt here"
+ *   npm install
+ *   npm exec -- tsx examples/chat.ts "your prompt here"
  */
 import { SandstormClient } from "../src/index.js";
 

--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@duvo/sandstorm-client",
       "version": "0.9.2",
+      "private": true,
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@duvo/sandstorm-client",
   "version": "0.9.2",
-  "description": "TypeScript client for the Sandstorm agent runtime — stream agent runs, manage memory, replay past runs.",
+  "private": true,
+  "description": "Repo-local TypeScript client source for the Sandstorm agent runtime.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,7 +1,5 @@
 /**
- * @duvo/sandstorm-client
- *
- * Minimal TypeScript client for Sandstorm — stream agent runs over SSE, manage
+ * Repo-local TypeScript client source for Sandstorm. Stream agent runs over SSE, manage
  * memory via slash-command-equivalent endpoints, replay past runs.
  *
  * Example:

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ Runs an agent request and returns a `text/event-stream` response.
 | `prompt` | `string` | Yes | - | The task for the agent |
 | `anthropic_api_key` | `string` | No | `$ANTHROPIC_API_KEY` | Anthropic key override |
 | `openrouter_api_key` | `string` | No | `$OPENROUTER_API_KEY` | OpenRouter key override |
-| `e2b_api_key` | `string` | No | `$E2B_API_KEY` | E2B key override |
+| `e2b_api_key` | `string` | No | `$E2B_API_KEY` | E2B runtime key override; used only when `runtime.provider` is `e2b` |
 | `model` | `string` | No | from config | Overrides `sandstorm.json` |
 | `max_turns` | `integer` | No | from config | Overrides `sandstorm.json` |
 | `timeout` | `integer` | No | `300` | Sandbox lifetime in seconds |
@@ -108,12 +108,14 @@ Returns the service version and status:
 }
 ```
 
-Add `?deep=true` to verify configured API keys and E2B reachability.
+Add `?deep=true` to verify configured API keys and the selected sandbox runtime. With the
+current E2B runtime, deep checks validate E2B reachability.
 
 ## `POST /webhooks/e2b`
 
-Receives E2B sandbox lifecycle events such as `created`, `updated`, and `killed`.
+Receives E2B runtime sandbox lifecycle events such as `created`, `updated`, and `killed`.
 
 - Verifies HMAC-SHA256 signatures when `SANDSTORM_WEBHOOK_SECRET` is set
 - Used automatically when `webhook_url` is configured in `sandstorm.json`
 - Can also be exercised with `ds webhook test`
+- E2B-only lifecycle helper; it applies when `runtime.provider` is `e2b` or omitted

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -16,7 +16,7 @@ Where Sandstorm differs:
 | --------------------------- | -------------------------------------------------- | ---------------------------------------- |
 | Runtime location            | Your infra (Railway / Fly / K8s / Docker / laptop) | Anthropic's infra only                   |
 | Models                      | Anthropic, OpenRouter, Vertex, Bedrock, Azure, any OpenAI-compatible base URL | Claude only                              |
-| Sandbox provider            | E2B (self-host or hosted)                          | Anthropic-operated                       |
+| Sandbox provider            | Configured runtime; E2B ships today                | Anthropic-operated                       |
 | Chat integration            | Slack bot in the repo                              | No chat wrappers                         |
 | Data flow                   | Everything stays in your network                   | Runtime traffic goes through Anthropic   |
 | Observability               | OTel → Langfuse / Phoenix / Langsmith / any OTLP   | Anthropic console only                   |
@@ -40,7 +40,7 @@ Where Sandstorm differs:
 | -------------------------- | -------------------------------------- | -------------------------------------- |
 | Language                   | Python (FastAPI)                       | TypeScript (Next.js)                   |
 | Deploy target              | Anywhere that runs Python              | Tight Vercel + Workflow DevKit coupling |
-| Sandbox                    | E2B (per-thread, paused between messages) | Vercel Sandbox                          |
+| Sandbox                    | Configured runtime; E2B ships today      | Vercel Sandbox                          |
 | Observability              | OTel to any backend                    | Vercel-native                           |
 | Replay & run archive       | Built in. `ds replay <run_id>`        | Not part of the template               |
 | Memory                     | JSONL, per (team_id, user_id)          | DIY                                    |
@@ -66,7 +66,7 @@ Where Sandstorm differs:
 
 | Axis                       | Sandstorm                         | Local-daemon Slack bots        |
 | -------------------------- | --------------------------------- | ------------------------------ |
-| Where the agent runs       | Fresh E2B sandbox per thread      | Your laptop / a single daemon  |
+| Where the agent runs       | Fresh sandbox per thread; E2B by default | Your laptop / a single daemon |
 | Blast radius of a bad prompt | Sandboxed, tear down or pause   | Whatever that laptop can reach |
 | Multi-user concurrency     | Per-thread sandbox pool           | Serialized via one process     |
 | Production deployment      | Docker / Railway / self-host      | "Keep my laptop on"            |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,28 @@ Drop a `sandstorm.json` file in your project root.
 | `skills_dir` | `string` | Directory containing Claude Code skills |
 | `allowed_tools` | `string[]` | Restrict the runtime to a subset of tools |
 | `template_skills` | `boolean` | Set `true` when required skills are already baked into the sandbox template |
-| `webhook_url` | `string` | Public URL for E2B lifecycle webhooks |
+| `runtime` | `object` | Sandbox runtime provider selection |
+| `webhook_url` | `string` | Public URL for E2B runtime lifecycle webhooks |
+
+## Runtime provider
+
+`runtime` selects where Sandstorm runs tools, files, commands, MCP servers, and agent work.
+The initial shape is:
+
+```json
+{
+  "runtime": {
+    "provider": "e2b"
+  }
+}
+```
+
+If `runtime` is omitted, Sandstorm defaults to E2B. Today `e2b` is the only runtime provider
+that ships with Sandstorm.
+
+**Runtime provider vs model provider:** `runtime.provider` controls where tools, files, and
+commands run. Model provider remains Anthropic, OpenRouter, Vertex AI, Bedrock, Azure Foundry,
+or a custom Anthropic-compatible proxy.
 
 ## Recommended customization model
 
@@ -166,7 +187,7 @@ For OpenRouter specifics, see the dedicated [OpenRouter guide](openrouter.md).
 
 ## Webhooks
 
-Set `webhook_url` in `sandstorm.json` to receive E2B sandbox lifecycle events:
+Set `webhook_url` in `sandstorm.json` to receive E2B runtime sandbox lifecycle events:
 
 ```json
 {
@@ -174,7 +195,9 @@ Set `webhook_url` in `sandstorm.json` to receive E2B sandbox lifecycle events:
 }
 ```
 
-When this field is configured, Sandstorm registers the webhook on server startup and deregisters it on shutdown.
+When this field is configured, Sandstorm registers the webhook on server startup and deregisters it
+on shutdown. These lifecycle webhook helpers are E2B-only and apply when
+`runtime.provider` is `e2b` or omitted.
 
 You can also manage webhooks from the CLI:
 

--- a/docs/custom-mcps.md
+++ b/docs/custom-mcps.md
@@ -85,10 +85,10 @@ uvx will fetch + run the package on demand. Make sure your deployment has
 
 ## Trust boundary
 
-`sandstorm.json` controls which MCP servers spin up inside your E2B sandbox.
-A malicious or buggy MCP package has the same access to the sandbox
-environment as the agent does: filesystem, network (subject to E2B's
-network policies), and whatever env vars you pass through.
+`sandstorm.json` controls which MCP servers spin up inside your configured sandbox runtime.
+A malicious or buggy MCP package has the same access to the sandbox environment as the agent
+does: filesystem, network (subject to the runtime provider's policies), and whatever env vars
+you pass through.
 
 Treat `ds add --custom <untrusted-package>` like `pip install` from an
 untrusted source. In practice:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,9 @@
 # Deployment Guide
 
-Core query execution in Sandstorm is stateless: each request creates an independent E2B sandbox, runs the agent, and tears it down. That makes concurrent agent runs straightforward. Two convenience features are still process-local by default: dashboard run history (`.sandstorm/runs.jsonl`) and Slack thread sandbox reuse.
+Core query execution in Sandstorm is stateless: each request creates an independent sandbox
+with the configured runtime, E2B by default, runs the agent, and tears it down. That makes
+concurrent agent runs straightforward. Two convenience features are still process-local by
+default: dashboard run history (`.sandstorm/runs.jsonl`) and Slack thread sandbox reuse.
 
 ## Production Server
 
@@ -59,10 +62,12 @@ All four agents run simultaneously in isolated sandboxes. They can't see each ot
 
 ## Scaling
 
-The Sandstorm server does almost no work itself -- it just proxies between your client and E2B. The real compute happens in E2B's cloud VMs. This means:
+The Sandstorm server does almost no work itself -- it proxies between your client and the
+configured sandbox runtime. With the default E2B runtime, the real compute happens in E2B's
+cloud VMs. This means:
 
 - **Horizontal scaling** -- run multiple Sandstorm instances behind a load balancer. No shared state to worry about.
-- **Bottleneck is E2B** -- your concurrent sandbox limit depends on your [E2B plan](https://e2b.dev/pricing). The free tier allows a handful; paid plans scale higher.
+- **Default-runtime bottleneck is E2B** -- your concurrent sandbox limit depends on your [E2B plan](https://e2b.dev/pricing). The free tier allows a handful; paid plans scale higher.
 - **CPU/memory on the server is minimal** -- each request holds an open SSE connection and streams stdout. A single 2-core machine can comfortably handle dozens of concurrent agents.
 
 ## Process-Local Features

--- a/docs/faq-vs-managed-agents.md
+++ b/docs/faq-vs-managed-agents.md
@@ -39,7 +39,7 @@ proprietary file formats.
 ## What Sandstorm is not
 
 - Not a hosted SaaS (today). There's no `sandstorm.cloud` tier, deploy it
-  yourself. See [deploy/README.md](../deploy/README.md) for paths.
+  yourself. See the [deployment guide](deployment.md) for paths.
 - Not a Langchain / LangGraph / CrewAI competitor. It uses the Claude Agent
   SDK for orchestration and focuses on the runtime + Slack + memory + replay
   layer above it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ If `ANTHROPIC_API_KEY` or `E2B_API_KEY` are missing, the guided flow prompts for
 ## Prerequisites
 
 - Python 3.11+
-- An [E2B](https://e2b.dev) API key
+- An [E2B](https://e2b.dev) API key for the default sandbox runtime
 - An [Anthropic](https://console.anthropic.com) API key, or an alternate provider configured through [OpenRouter](openrouter.md) or the provider env vars in [configuration](configuration.md)
 - `uv` only if you want a source checkout workflow
 
@@ -155,7 +155,7 @@ ds init
 
 Each request follows the same basic path:
 
-1. Sandstorm creates a fresh E2B sandbox.
+1. Sandstorm creates a fresh sandbox with the configured runtime, E2B by default.
 2. It uploads your config, prompt, and any files.
 3. The Claude Agent SDK runs inside the sandbox with the configured tools.
 4. Sandstorm streams events back over CLI, API, or Slack.

--- a/docs/managed-agents-interop.md
+++ b/docs/managed-agents-interop.md
@@ -26,7 +26,7 @@ What it does **not** ship:
 
 - **A scheduler**: cron (sub-hourly, unlike Claude Code Routines' 1-hour
   minimum) that can fire Managed Agents sessions or run agents in your
-  own E2B sandbox
+  own sandbox runtime, E2B by default
 - **A Slack bot**: @mentions, DMs, slash commands, App Home, pause/resume
   per-thread sandboxes
 - **Multi-provider**: Anthropic, OpenRouter, Vertex, Bedrock, Azure
@@ -105,15 +105,14 @@ to stay self-hosted, use Sandstorm.
 
 ## Migrating from the Anthropic Slack cookbook recipe
 
-If you followed the [Claude Managed Agents Slack data bot](
-https://platform.claude.com/cookbook/managed-agents-slack-data-bot) recipe,
+If you followed the [Claude Managed Agents Slack data bot](https://platform.claude.com/cookbook/managed-agents-slack-data-bot) recipe,
 here's the direct Sandstorm equivalent:
 
 | Recipe step | Sandstorm equivalent |
 | ----------- | -------------------- |
 | `pip install slack-bolt anthropic` | `pip install "duvo-sandstorm[slack]"` |
 | Hand-roll a Bolt app with `@app.event("app_mention")` | Already wired; run `ds slack setup` |
-| Thread a CMA session through `anthropic.beta.sessions.create` | Set `"model": "sonnet"` in `sandstorm.json`; agent runs in your E2B sandbox |
+| Thread a CMA session through `anthropic.beta.sessions.create` | Set `"model": "sonnet"` in `sandstorm.json`; agent runs in your configured sandbox runtime |
 | Wire file upload | Already wired (see `_download_thread_files`) |
 | Wire feedback UI | Already wired (feedback buttons in the metadata footer) |
 | Redeploy to update prompts | Edit `sandstorm.json`; the next run picks up changes without a restart |

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -145,7 +145,7 @@ or reinstall from the Slack app dashboard manually.
 | `SLACK_APP_TOKEN` | Yes (Socket Mode) | -- | App-level token (`xapp-...`) for Socket Mode |
 | `SLACK_SIGNING_SECRET` | Yes (HTTP mode) | -- | Signing secret for request verification in HTTP mode |
 | `ANTHROPIC_API_KEY` | Yes* | -- | Anthropic API key (or use OpenRouter) |
-| `E2B_API_KEY` | Yes | -- | E2B sandbox API key |
+| `E2B_API_KEY` | Yes for E2B runtime | -- | Default E2B sandbox runtime API key |
 | `OPENROUTER_API_KEY` | No | -- | OpenRouter key (if using OpenRouter) |
 
 *Or equivalent provider key, see [configuration](configuration.md#providers) for provider setup.

--- a/src/sandstorm/config.py
+++ b/src/sandstorm/config.py
@@ -49,6 +49,7 @@ _MCP_ENV_VAR_PATTERN = re.compile(
     r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
 )
 _LOADED_DOTENV_VALUES: dict[str, str] = {}
+_RUNTIME_PROVIDERS = frozenset({"e2b"})
 
 # ── mtime-based config cache ──────────────────────────────────────────────────
 
@@ -147,6 +148,7 @@ def _validate_sandstorm_config(raw: dict) -> dict:
         "mcp_servers": ((dict,), "dict"),
         "skills_dir": ((str,), "str"),
         "allowed_tools": ((list,), "list"),
+        "runtime": ((dict,), "dict"),
         "webhook_url": ((str,), "str"),
         "timeout": ((int,), "int"),
         "template_skills": ((bool,), "bool"),
@@ -204,6 +206,23 @@ def _validate_sandstorm_config(raw: dict) -> dict:
     if "model" in validated and not validated["model"].strip():
         logger.warning("sandstorm.json: model must be a non-empty string — skipping")
         del validated["model"]
+
+    if "runtime" in validated:
+        runtime = validated["runtime"]
+        provider = runtime.get("provider")
+        if not isinstance(provider, str) or provider not in _RUNTIME_PROVIDERS:
+            logger.warning(
+                "sandstorm.json: runtime.provider must be one of %s — skipping",
+                ", ".join(sorted(_RUNTIME_PROVIDERS)),
+            )
+            del validated["runtime"]
+        else:
+            for runtime_key in sorted(set(runtime) - {"provider"}):
+                logger.warning(
+                    "sandstorm.json: unknown runtime field %r — ignoring",
+                    runtime_key,
+                )
+            validated["runtime"] = {"provider": provider}
 
     return validated
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,102 @@
+import json
+import re
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_ROOTS = (
+    ROOT / "docs",
+    ROOT / "examples",
+    ROOT / "deploy",
+)
+DOC_FILES = (
+    ROOT / "README.md",
+    ROOT / "clients" / "typescript" / "README.md",
+)
+
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _iter_doc_files() -> list[Path]:
+    files = set(DOC_FILES)
+    for root in DOC_ROOTS:
+        files.update(root.rglob("*.md"))
+    return sorted(files)
+
+
+def _slugify(heading: str) -> str:
+    heading = re.sub(r"<[^>]+>", "", heading)
+    heading = heading.replace("`", "")
+    heading = re.sub(r"[^\w\s-]", "", heading.lower())
+    return re.sub(r"[\s-]+", "-", heading).strip("-")
+
+
+def _anchors(markdown_path: Path) -> set[str]:
+    text = markdown_path.read_text(encoding="utf-8")
+    text = _FENCED_CODE_RE.sub("", text)
+    return {_slugify(match.group(2).strip()) for match in _HEADING_RE.finditer(text)}
+
+
+def _local_link_target(source: Path, raw_target: str) -> tuple[Path, str] | None:
+    target = raw_target.strip()
+    parsed = urlsplit(target)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if target.startswith("#"):
+        return source, parsed.fragment
+    if not parsed.path:
+        return None
+    return (source.parent / unquote(parsed.path)).resolve(), parsed.fragment
+
+
+def test_local_markdown_links_resolve():
+    failures: list[str] = []
+
+    for source in _iter_doc_files():
+        text = source.read_text(encoding="utf-8")
+        text = _FENCED_CODE_RE.sub("", text)
+        for match in _MARKDOWN_LINK_RE.finditer(text):
+            target = _local_link_target(source, match.group(1))
+            if target is None:
+                continue
+
+            linked_path, fragment = target
+            if not linked_path.exists():
+                failures.append(f"{source.relative_to(ROOT)} -> {match.group(1)}")
+                continue
+
+            if fragment and linked_path.suffix == ".md":
+                anchors = _anchors(linked_path)
+                if fragment not in anchors:
+                    failures.append(
+                        f"{source.relative_to(ROOT)} -> {match.group(1)} missing anchor"
+                    )
+
+    assert failures == []
+
+
+def test_typescript_client_is_not_documented_as_npm_package():
+    text = "\n".join(path.read_text(encoding="utf-8") for path in _iter_doc_files())
+
+    assert "npm install @duvo/sandstorm-client" not in text
+    assert "pnpm add @duvo/sandstorm-client" not in text
+
+
+def test_typescript_client_package_is_private():
+    package_json = json.loads(
+        (ROOT / "clients" / "typescript" / "package.json").read_text(encoding="utf-8")
+    )
+
+    assert package_json["private"] is True
+
+
+def test_private_typescript_client_is_not_published_by_release_workflow():
+    package_json = json.loads(
+        (ROOT / "clients" / "typescript" / "package.json").read_text(encoding="utf-8")
+    )
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+
+    assert package_json["private"] is True
+    assert "npm publish" not in workflow

--- a/tests/test_sandbox_skills.py
+++ b/tests/test_sandbox_skills.py
@@ -69,6 +69,25 @@ class TestValidateSandstormConfigSkills:
         config = _validate_sandstorm_config({"template_skills": 1})
         assert "template_skills" not in config
 
+    def test_runtime_provider_e2b_valid(self):
+        config = _validate_sandstorm_config({"runtime": {"provider": "e2b"}})
+        assert config["runtime"] == {"provider": "e2b"}
+
+    def test_runtime_wrong_type_dropped(self):
+        config = _validate_sandstorm_config({"runtime": "e2b"})
+        assert "runtime" not in config
+
+    def test_runtime_unknown_provider_dropped(self):
+        config = _validate_sandstorm_config({"runtime": {"provider": "local"}})
+        assert "runtime" not in config
+
+    def test_runtime_extra_keys_stripped_with_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="sandstorm.config"):
+            config = _validate_sandstorm_config({"runtime": {"provider": "e2b", "region": "us"}})
+
+        assert config["runtime"] == {"provider": "e2b"}
+        assert "unknown runtime field 'region'" in caplog.text
+
     def test_max_turns_must_be_positive(self):
         config = _validate_sandstorm_config({"max_turns": 0})
         assert "max_turns" not in config


### PR DESCRIPTION
## Summary
- document runtime.provider with E2B as the default runtime
- clarify the TypeScript client is repo-local/private and remove npm publish automation
- add docs/link regression tests

## Tests
- uv run pytest tests/
- ruff check src/ tests/
- ruff format --check src/ tests/