### PR TITLE
feat: google chat integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "duvo-sandstorm"
 version = "0.9.2"
 description = "Open-source runtime for general-purpose AI agents in isolated sandboxes."
-keywords = ["ai-agents", "anthropic", "claude", "e2b", "fastapi", "openrouter", "sandbox", "slack"]
+keywords = ["ai-agents", "anthropic", "claude", "e2b", "fastapi", "google-chat", "openrouter", "sandbox", "slack"]
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
@@ -34,6 +34,11 @@ slack = [
     "slack-bolt>=1.28.0",
     "slack-sdk>=3.34.0",
     "aiohttp>=3.9.0",
+]
+gchat = [
+    "google-api-python-client>=2.100.0",
+    "google-auth>=2.25.0",
+    "google-auth-httplib2>=0.2.0",
 ]
 client = ["httpx>=0.27", "httpx-sse>=0.4"]
 dev = [

--- a/src/sandstorm/cli.py
+++ b/src/sandstorm/cli.py
@@ -1668,3 +1668,243 @@ def _do_slack_start_socket() -> None:
     except KeyboardInterrupt as exc:
         click.echo("Interrupted.", err=True)
         raise SystemExit(130) from exc
+
+
+@cli.group()
+def gchat() -> None:
+    """Sandstorm Google Chat bot."""
+
+
+@gchat.command("setup")
+def gchat_setup() -> None:
+    """Interactive setup wizard — configures Google Chat integration."""
+    load_dotenv()
+
+    click.echo("\n  Sandstorm Google Chat Setup")
+    click.echo("  " + "-" * 28 + "\n")
+
+    # Step 1: Check for google-api-python-client
+    try:
+        import googleapiclient  # noqa: F401
+    except ImportError:
+        click.echo(
+            '  Error: Google Chat dependencies not installed.\n'
+            '  Run: pip install "duvo-sandstorm[gchat]"',
+            err=True,
+        )
+        raise SystemExit(1)
+
+    # Step 2: Service account key
+    click.echo("  Step 1: Service account credentials\n")
+    click.echo("  You need a GCP service account JSON key file.")
+    click.echo("  Create one at: https://console.cloud.google.com/iam-admin/serviceaccounts\n")
+
+    key_path = click.prompt("  Path to service account JSON key file", type=str).strip()
+    key_path_resolved = Path(key_path).resolve()
+    if not key_path_resolved.exists():
+        click.echo(f"  Error: File not found: {key_path_resolved}", err=True)
+        raise SystemExit(1)
+
+    # Validate it's valid JSON
+    import json as _json
+    try:
+        with open(key_path_resolved) as f:
+            key_data = _json.load(f)
+        if "client_email" not in key_data:
+            click.echo("  Warning: JSON key file doesn't look like a service account key.", err=True)
+    except _json.JSONDecodeError:
+        click.echo("  Error: File is not valid JSON.", err=True)
+        raise SystemExit(1)
+
+    # Step 3: Project number
+    click.echo("\n  Step 2: GCP project number\n")
+    click.echo("  Find it at: https://console.cloud.google.com → Project Info")
+    project_number = click.prompt("  GCP project number", type=str).strip()
+
+    # Step 4: Save to .env
+    env_path = str(Path.cwd() / ".env")
+    set_key(env_path, "GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", str(key_path_resolved))
+    set_key(env_path, "GOOGLE_CHAT_PROJECT_NUMBER", project_number)
+    click.echo(
+        f"\n  Saved GOOGLE_CHAT_SERVICE_ACCOUNT_KEY and GOOGLE_CHAT_PROJECT_NUMBER to .env\n"
+    )
+
+    # Step 5: Chat API configuration instructions
+    click.echo("  Step 3: Configure the Chat API\n")
+    click.echo("  1. Go to: https://console.cloud.google.com/apis/api/chat.googleapis.com")
+    click.echo("  2. Enable the Google Chat API")
+    click.echo("  3. Go to Configuration tab and set:")
+    click.echo("     - HTTP endpoint URL: https://<your-server>/gchat/events")
+    click.echo("     - Enable interactive features")
+    click.echo("     - Add slash commands:")
+    click.echo("       /remember (ID: 1), /team_remember (ID: 2), /channel_remember (ID: 3),")
+    click.echo("       /forget (ID: 4), /memories (ID: 5), /model (ID: 6), /cancel (ID: 7)")
+    click.echo("     - Enable App Home")
+    click.echo()
+    click.echo("  Note: Google Chat requires an HTTPS endpoint (no socket mode).")
+    click.echo("  For development, use ngrok or cloudflared to tunnel.\n")
+
+    # Step 6: Test connectivity
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+
+        credentials = service_account.Credentials.from_service_account_file(
+            str(key_path_resolved),
+            scopes=["https://www.googleapis.com/auth/chat.bot"],
+        )
+        service = build("chat", "v1", credentials=credentials)
+        # A simple API call to verify the credentials work
+        service.spaces().list(pageSize=1).execute()
+        click.echo("  ✓ Service account credentials verified.\n")
+    except Exception as exc:
+        click.echo(f"  Warning: Could not verify credentials: {exc}", err=True)
+        click.echo("  The credentials may still work — verify after configuring the Chat API.\n")
+
+    click.echo("  Setup complete! Start with: ds gchat start\n")
+
+
+@gchat.command("verify")
+def gchat_verify() -> None:
+    """Preflight checks for Google Chat integration."""
+    load_dotenv()
+    import json as _json
+
+    checks: list[tuple[str, bool, str]] = []
+
+    # Check 1: Service account key
+    key_path = os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "")
+    if not key_path:
+        checks.append(("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", False, "not set"))
+    elif not Path(key_path).exists():
+        checks.append(("Service account key file", False, f"not found: {key_path}"))
+    else:
+        try:
+            with open(key_path) as f:
+                key_data = _json.load(f)
+            if "client_email" in key_data:
+                checks.append(("Service account key", True, key_data["client_email"]))
+            else:
+                checks.append(("Service account key", False, "missing client_email"))
+        except Exception:
+            checks.append(("Service account key", False, "invalid JSON"))
+
+    # Check 2: Project number
+    project_number = os.environ.get("GOOGLE_CHAT_PROJECT_NUMBER", "")
+    if project_number:
+        checks.append(("GOOGLE_CHAT_PROJECT_NUMBER", True, project_number))
+    else:
+        checks.append(("GOOGLE_CHAT_PROJECT_NUMBER", False, "not set"))
+
+    # Check 3: Google API client
+    try:
+        import googleapiclient  # noqa: F401
+        checks.append(("google-api-python-client", True, "installed"))
+    except ImportError:
+        checks.append(("google-api-python-client", False, 'pip install "duvo-sandstorm[gchat]"'))
+
+    # Print results
+    click.echo("\n  Google Chat preflight\n")
+    all_pass = True
+    for name, passed, detail in checks:
+        icon = "✓" if passed else "✗"
+        click.echo(f"  {icon} {name}: {detail}")
+        if not passed:
+            all_pass = False
+
+    click.echo()
+    if not all_pass:
+        click.echo("  Some checks failed. Run `ds gchat setup` to configure.\n")
+        raise SystemExit(1)
+    click.echo("  All checks passed!\n")
+
+
+@gchat.command("start")
+@click.option("--host", default="0.0.0.0", help="Bind address.")
+@click.option("--port", "-p", default=3000, type=int, help="Bind port.")
+def gchat_start(host: str, port: int) -> None:
+    """Start the FastAPI server with Google Chat endpoint."""
+    load_dotenv()
+
+    if not os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY"):
+        click.echo(
+            "Error: GOOGLE_CHAT_SERVICE_ACCOUNT_KEY not set.\n"
+            "Run `ds gchat setup` first.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format=_LOG_FORMAT,
+        datefmt=_LOG_DATEFMT,
+        stream=sys.stderr,
+    )
+
+    try:
+        import uvicorn
+        from .main import app
+
+        click.echo(f"Starting Sandstorm with Google Chat on {host}:{port}...")
+        uvicorn.run(app, host=host, port=port)
+    except ImportError as exc:
+        click.echo("Error: uvicorn not available.", err=True)
+        raise SystemExit(1) from exc
+    except KeyboardInterrupt as exc:
+        click.echo("Interrupted.", err=True)
+        raise SystemExit(130) from exc
+
+
+@gchat.command("test")
+@click.option("--space", required=True, help="Google Chat space name (e.g. spaces/AAAA_BBBB)")
+def gchat_test(space: str) -> None:
+    """Run live integration test against a Google Chat space."""
+    load_dotenv()
+
+    key_path = os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "")
+    if not key_path:
+        click.echo("Error: GOOGLE_CHAT_SERVICE_ACCOUNT_KEY not set.", err=True)
+        raise SystemExit(1)
+
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+    except ImportError:
+        click.echo('Error: pip install "duvo-sandstorm[gchat]"', err=True)
+        raise SystemExit(1)
+
+    click.echo(f"\n  Testing Google Chat integration in {space}\n")
+
+    # Step 1: Verify credentials
+    try:
+        credentials = service_account.Credentials.from_service_account_file(
+            key_path,
+            scopes=["https://www.googleapis.com/auth/chat.bot"],
+        )
+        service = build("chat", "v1", credentials=credentials)
+        click.echo("  ✓ Credentials valid")
+    except Exception as exc:
+        click.echo(f"  ✗ Credentials invalid: {exc}", err=True)
+        raise SystemExit(1)
+
+    # Step 2: Send test message
+    try:
+        result = service.spaces().messages().create(
+            parent=space,
+            body={"text": "🔧 Sandstorm integration test — this message will be deleted."},
+        ).execute()
+        msg_name = result.get("name", "")
+        click.echo("  ✓ Sent test message")
+    except Exception as exc:
+        click.echo(f"  ✗ Failed to send message: {exc}", err=True)
+        raise SystemExit(1)
+
+    # Step 3: Delete test message
+    if msg_name:
+        try:
+            service.spaces().messages().delete(name=msg_name).execute()
+            click.echo("  ✓ Deleted test message")
+        except Exception as exc:
+            click.echo(f"  ✗ Failed to delete test message: {exc}", err=True)
+
+    click.echo("\n  Integration test passed!\n")

--- a/src/sandstorm/gchat.py
+++ b/src/sandstorm/gchat.py
@@ -12,6 +12,25 @@ from .store import run_store
 
 logger = logging.getLogger(__name__)
 
+_UNICODE_TO_SHORTCODE = {
+    "\U0001f440": "eyes",
+    "\U0001f44d": "+1",
+    "\U0001f44e": "-1",
+    "\U0001f680": "rocket",
+    "✅": "white_check_mark",
+    "❌": "x",
+    "\U0001f525": "fire",
+    "\U0001f4a1": "bulb",
+    "\U0001f6a8": "rotating_light",
+    "\U0001f3af": "dart",
+    "\U0001f50d": "mag",
+    "\U0001f4dd": "memo",
+}
+
+
+def unicode_to_shortcode(emoji: str) -> str | None:
+    return _UNICODE_TO_SHORTCODE.get(emoji)
+
 
 def parse_event_type(body: dict) -> str:
     """Determine the event type from a Google Chat event payload."""

--- a/src/sandstorm/gchat.py
+++ b/src/sandstorm/gchat.py
@@ -7,6 +7,7 @@ import logging
 import time
 
 from .memory import memory_store
+from .platform import BINARY_MIME_PREFIXES, MAX_FILE_SIZE, unique_filename
 from .store import run_store
 
 logger = logging.getLogger(__name__)
@@ -181,6 +182,93 @@ def dispatch_slash_command(
         return {"text": f"Run `{run.id}` is already finishing."}
 
     return {"text": "Unknown command."}
+
+async def fetch_thread_messages(service, space_name: str, thread_key: str) -> list[dict]:
+    """Fetch all messages in a Google Chat thread.
+
+    Returns normalized message dicts: {user, text, files}
+    """
+    try:
+        response = await asyncio.to_thread(
+            service.spaces().messages().list(
+                parent=space_name,
+                filter=f'thread.name = "{thread_key}"',
+            ).execute
+        )
+        raw_messages = response.get("messages", [])
+        normalized = []
+        for msg in raw_messages:
+            sender = msg.get("sender", {})
+            user = sender.get("name", "unknown")
+            text = msg.get("text", "").strip()
+            files = []
+            for attachment in msg.get("attachment", []):
+                data_ref = attachment.get("attachmentDataRef", {})
+                files.append({
+                    "name": attachment.get("name", "unknown"),
+                    "mimetype": attachment.get("contentType", "application/octet-stream"),
+                    "size": int(data_ref.get("length", 0)),
+                    "resource_name": data_ref.get("resourceName", ""),
+                })
+            entry: dict = {"user": user, "text": text}
+            if files:
+                entry["files"] = files
+            normalized.append(entry)
+        return normalized
+    except Exception:
+        logger.warning("Failed to fetch thread messages", exc_info=True)
+        return []
+
+
+async def download_thread_files(
+    service, messages: list[dict], bot_user_id: str
+) -> tuple[dict[str, str], dict[str, bytes]]:
+    """Download files from Google Chat thread messages.
+
+    Returns (text_files, binary_files) matching the Slack function signature.
+    """
+    text_files: dict[str, str] = {}
+    binary_files: dict[str, bytes] = {}
+    seen: set[str] = set()
+
+    for msg in messages:
+        if msg.get("user") == bot_user_id:
+            continue
+
+        for f in msg.get("files", []):
+            raw_name = f.get("name", "unknown")
+            name = unique_filename(raw_name, seen)
+            mimetype = f.get("mimetype", "")
+            size = f.get("size", 0)
+            is_binary = any(mimetype.startswith(prefix) for prefix in BINARY_MIME_PREFIXES)
+            resource_name = f.get("resource_name", "")
+
+            if size > MAX_FILE_SIZE:
+                logger.warning("Skipping large file: %s (%d bytes)", name, size)
+                continue
+
+            if not resource_name:
+                continue
+
+            try:
+                response = await asyncio.to_thread(
+                    service.media().download(resourceName=resource_name).execute
+                )
+                if is_binary:
+                    binary_files[name] = response
+                else:
+                    binary_files[name] = response  # treat unknown as binary
+                    # Try to decode as text
+                    try:
+                        text_files[name] = response.decode("utf-8")
+                        del binary_files[name]
+                    except (UnicodeDecodeError, AttributeError):
+                        pass
+            except Exception:
+                logger.warning("Failed to download file: %s", name, exc_info=True)
+
+    return text_files, binary_files
+
 
 FLUSH_INTERVAL = 2.0
 

--- a/src/sandstorm/gchat.py
+++ b/src/sandstorm/gchat.py
@@ -6,7 +6,181 @@ import asyncio
 import logging
 import time
 
+from .memory import memory_store
+from .store import run_store
+
 logger = logging.getLogger(__name__)
+
+
+def parse_event_type(body: dict) -> str:
+    """Determine the event type from a Google Chat event payload."""
+    event_type = body.get("type", "")
+
+    if event_type == "ADDED_TO_SPACE":
+        return "added_to_space"
+    if event_type == "MESSAGE":
+        message = body.get("message", {})
+        if message.get("slashCommand"):
+            return "slash_command"
+        space_type = body.get("space", {}).get("type", "")
+        if space_type == "DM":
+            return "dm_message"
+        return "mention"
+    if event_type == "CARD_CLICKED":
+        return "card_clicked"
+    if event_type == "APP_HOME":
+        return "app_home"
+    if event_type == "REACTION_ADDED":
+        return "reaction_added"
+    return "unknown"
+
+
+def build_metadata_cards(
+    run_id: str,
+    model: str | None,
+    cost_usd: float | None,
+    num_turns: int | None,
+    duration_secs: float | None,
+) -> list[dict]:
+    """Build a Cards v2 footer with run metadata and feedback buttons."""
+    parts: list[str] = []
+    if model:
+        parts.append(f"Model: {model}")
+    if num_turns is not None:
+        parts.append(f"Turns: {num_turns}")
+    if cost_usd is not None:
+        parts.append(f"Cost: ${cost_usd:.4f}")
+    if duration_secs is not None:
+        parts.append(f"Duration: {duration_secs:.1f}s")
+
+    return [
+        {
+            "cardId": f"metadata_{run_id}",
+            "card": {
+                "sections": [
+                    {
+                        "widgets": [
+                            {"textParagraph": {"text": " | ".join(parts)}}
+                            if parts
+                            else {},
+                            {
+                                "buttonList": {
+                                    "buttons": [
+                                        {
+                                            "text": "\U0001f44d Helpful",
+                                            "onClick": {
+                                                "action": {
+                                                    "actionMethodName": "sandstorm_feedback",
+                                                    "parameters": [
+                                                        {
+                                                            "key": "run_id",
+                                                            "value": run_id,
+                                                        },
+                                                        {
+                                                            "key": "sentiment",
+                                                            "value": "positive",
+                                                        },
+                                                    ],
+                                                }
+                                            },
+                                        },
+                                        {
+                                            "text": "\U0001f44e Not helpful",
+                                            "onClick": {
+                                                "action": {
+                                                    "actionMethodName": "sandstorm_feedback",
+                                                    "parameters": [
+                                                        {
+                                                            "key": "run_id",
+                                                            "value": run_id,
+                                                        },
+                                                        {
+                                                            "key": "sentiment",
+                                                            "value": "negative",
+                                                        },
+                                                    ],
+                                                }
+                                            },
+                                        },
+                                    ]
+                                }
+                            },
+                        ]
+                    }
+                ]
+            },
+        }
+    ]
+
+
+def dispatch_slash_command(
+    body: dict, *, team_id: str | None, user_id: str | None
+) -> dict:
+    """Route a Google Chat slash command by commandId to the appropriate handler."""
+    command = body.get("message", {}).get("slashCommand", {})
+    command_id = str(command.get("commandId", ""))
+    text = body.get("message", {}).get("argumentText", "").strip()
+    channel_id = body.get("space", {}).get("name", "")
+
+    if command_id == "1":  # /remember
+        if not text:
+            return {"text": "Usage: `/remember <fact>`."}
+        memory_store.remember(team_id, user_id, text, scope="user")
+        return {"text": f"Remembered (user): _{text}_"}
+
+    elif command_id == "2":  # /team_remember
+        if not text:
+            return {"text": "Usage: `/team_remember <fact>`."}
+        memory_store.remember(team_id, user_id, text, scope="team")
+        return {"text": f"Remembered (team): _{text}_"}
+
+    elif command_id == "3":  # /channel_remember
+        if not text:
+            return {"text": "Usage: `/channel_remember <fact>`."}
+        if not channel_id:
+            return {"text": "Channel-scoped memory requires a space context."}
+        memory_store.remember(
+            team_id, user_id, text, scope="channel", channel_id=channel_id
+        )
+        return {"text": f"Remembered (channel): _{text}_"}
+
+    elif command_id == "4":  # /forget
+        if not text:
+            return {"text": "Usage: `/forget <substring>`."}
+        deleted = memory_store.forget(team_id, user_id, text, channel_id=channel_id)
+        if deleted:
+            return {
+                "text": f"Forgot {deleted} memor{'y' if deleted == 1 else 'ies'}."
+            }
+        return {"text": f"No memory matched `{text}`."}
+
+    elif command_id == "5":  # /memories
+        memories = memory_store.list(team_id, user_id, channel_id=channel_id)
+        if not memories:
+            return {"text": "No memories yet. Use `/remember <fact>` to add one."}
+        lines = [f"{i + 1}. [{m.scope}] {m.text}" for i, m in enumerate(memories)]
+        return {"text": "Your memories:\n" + "\n".join(lines)}
+
+    elif command_id == "6":  # /model
+        return {"text": "Model override not yet implemented for Google Chat."}
+
+    elif command_id == "7":  # /cancel
+        from .cancellation import request_cancellation
+
+        run = run_store.find_most_recent(
+            lambda r: (
+                r.team_id == team_id
+                and r.user_id == user_id
+                and r.status == "running"
+            )
+        )
+        if run is None:
+            return {"text": "You have no in-flight run to cancel."}
+        if request_cancellation(run.id):
+            return {"text": f"Cancelled run `{run.id}`."}
+        return {"text": f"Run `{run.id}` is already finishing."}
+
+    return {"text": "Unknown command."}
 
 FLUSH_INTERVAL = 2.0
 

--- a/src/sandstorm/gchat.py
+++ b/src/sandstorm/gchat.py
@@ -1,0 +1,73 @@
+"""Google Chat bot integration for Sandstorm."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+FLUSH_INTERVAL = 2.0
+
+
+class GChatStreamer:
+    """Buffers text chunks, updates the Google Chat message every ~2 seconds.
+
+    Implements the same duck-typed interface as Slack's chat_stream() result:
+      async append(*, markdown_text: str) -> None
+      async stop(blocks: list[dict] | None = None) -> None
+    """
+
+    def __init__(self, service, space_name: str, message_name: str, thread_key: str):
+        self._service = service
+        self._space_name = space_name
+        self._message_name = message_name
+        self._thread_key = thread_key
+        self._buffer = ""
+        self._accumulated = ""
+        self._last_update = time.monotonic()
+
+    async def append(self, *, text: str = "", markdown_text: str = ""):
+        content = markdown_text or text
+        self._buffer += content
+        now = time.monotonic()
+        if now - self._last_update > FLUSH_INTERVAL:
+            await self._flush()
+
+    async def stop(self, blocks=None, cards=None):
+        await self._flush(final=True, cards=cards or blocks)
+
+    async def _flush(self, final=False, cards=None):
+        if not self._buffer and not final:
+            return
+        self._accumulated += self._buffer
+        self._buffer = ""
+        self._last_update = time.monotonic()
+        if not self._accumulated and not cards:
+            return
+
+        body: dict = {}
+        if self._accumulated:
+            body["text"] = self._accumulated
+        if cards:
+            body["cardsV2"] = cards
+
+        update_mask = ",".join(body.keys())
+        try:
+            await asyncio.to_thread(
+                self._service.spaces()
+                .messages()
+                .update(
+                    name=self._message_name,
+                    updateMask=update_mask,
+                    body=body,
+                )
+                .execute
+            )
+        except Exception:
+            logger.error(
+                "Failed to update Google Chat message %s",
+                self._message_name,
+                exc_info=True,
+            )

--- a/src/sandstorm/gchat_app_home.py
+++ b/src/sandstorm/gchat_app_home.py
@@ -1,0 +1,176 @@
+"""Google Chat App Home — Cards v2 rendering."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from .cancellation import is_registered
+from .config import load_sandstorm_config
+from .memory import memory_store
+from .store import run_store
+
+logger = logging.getLogger(__name__)
+
+
+def _status_section(tenant: str | None, user_id: str | None) -> dict:
+    most_recent = run_store.find_most_recent(
+        lambda r: r.team_id == tenant and r.user_id == user_id
+    )
+    if most_recent is None:
+        text = "No Sandstorm runs yet."
+    else:
+        cost = f"${most_recent.cost_usd:.4f}" if most_recent.cost_usd is not None else "n/a"
+        duration = (
+            f"{most_recent.duration_secs:.1f}s" if most_recent.duration_secs is not None else "n/a"
+        )
+        text = (
+            f"Most recent run: {most_recent.id} ({most_recent.status}) | "
+            f"model: {most_recent.model or 'default'} | "
+            f"cost: {cost} | duration: {duration}"
+        )
+    return {"widgets": [{"textParagraph": {"text": text}}]}
+
+
+def _active_run_section(tenant: str | None, user_id: str | None) -> dict | None:
+    active = run_store.find_most_recent(
+        lambda r: r.team_id == tenant and r.user_id == user_id and r.status == "running"
+    )
+    if active is None or not is_registered(active.id):
+        return None
+    return {
+        "header": "Active run",
+        "widgets": [
+            {"textParagraph": {"text": f"{active.id} — {active.prompt}"}},
+            {
+                "buttonList": {
+                    "buttons": [{
+                        "text": "Cancel",
+                        "color": {"red": 0.8, "green": 0.1, "blue": 0.1, "alpha": 1},
+                        "onClick": {
+                            "action": {
+                                "actionMethodName": "sandstorm_cancel_run",
+                                "parameters": [{"key": "run_id", "value": active.id}],
+                            }
+                        },
+                    }]
+                }
+            },
+        ],
+    }
+
+
+def _memory_section(team_id: str | None, user_id: str | None) -> dict:
+    personal = memory_store.list(team_id, user_id, scope="user")
+    team_scope = memory_store.list(team_id, user_id, scope="team")
+
+    widgets: list[dict] = []
+
+    if personal:
+        widgets.append({"textParagraph": {"text": "<b>Your memories</b>"}})
+        for mem in personal:
+            widgets.append({
+                "decoratedText": {
+                    "text": mem.text,
+                    "button": {
+                        "text": "Forget",
+                        "color": {"red": 0.8, "green": 0.1, "blue": 0.1, "alpha": 1},
+                        "onClick": {
+                            "action": {
+                                "actionMethodName": "sandstorm_forget_memory",
+                                "parameters": [{"key": "memory_id", "value": mem.id}],
+                            }
+                        },
+                    },
+                }
+            })
+    else:
+        widgets.append({
+            "textParagraph": {"text": "No personal memories yet. Use /remember in any space."}
+        })
+
+    if team_scope:
+        widgets.append({"textParagraph": {"text": "<b>Team memories</b> (read-only)"}})
+        for mem in team_scope:
+            widgets.append({"textParagraph": {"text": f"• {mem.text}"}})
+
+    return {"header": "Memory", "widgets": widgets}
+
+
+def _channel_defaults_section(
+    sandstorm_config: Mapping[str, object] | None,
+) -> dict | None:
+    channels = sandstorm_config.get("channels") if isinstance(sandstorm_config, Mapping) else None
+    if not isinstance(channels, Mapping) or not channels:
+        return None
+    lines = []
+    for channel_id, overlay in sorted(channels.items()):
+        if not isinstance(overlay, Mapping):
+            continue
+        starter = overlay.get("starter", "default")
+        model = overlay.get("model", "default")
+        lines.append(f"• {channel_id} → starter: {starter}, model: {model}")
+    if not lines:
+        return None
+    return {
+        "header": "Space defaults",
+        "widgets": [{"textParagraph": {"text": "\n".join(lines)}}],
+    }
+
+
+def _triggers_section(sandstorm_config: Mapping[str, object] | None) -> dict | None:
+    from .triggers import load_triggers
+
+    if not sandstorm_config:
+        return None
+    try:
+        triggers = load_triggers(sandstorm_config)
+    except ValueError:
+        return None
+    if not triggers:
+        return None
+    lines = []
+    for t in triggers:
+        if t.type == "cron":
+            lines.append(f"• {t.name} (cron: {t.schedule})")
+        elif t.type == "webhook":
+            secret = "secret-required" if t.secret else "OPEN"
+            lines.append(f"• {t.name} (webhook: {t.path} · {secret})")
+        else:
+            ch = ", ".join(t.channels) or "any space"
+            lines.append(f"• {t.name} (:{t.emoji}: in {ch})")
+    return {
+        "header": "Triggers",
+        "widgets": [{"textParagraph": {"text": "\n".join(lines)}}],
+    }
+
+
+def build_home_card(*, team_id: str | None, user_id: str | None) -> dict:
+    """Build the App Home card (Cards v2 format)."""
+    config = load_sandstorm_config()
+    sections = [_status_section(team_id, user_id)]
+
+    active_run = _active_run_section(team_id, user_id)
+    if active_run:
+        sections.append(active_run)
+
+    channel_defaults = _channel_defaults_section(config)
+    if channel_defaults:
+        sections.append(channel_defaults)
+
+    sections.append(_memory_section(team_id, user_id))
+
+    triggers = _triggers_section(config)
+    if triggers:
+        sections.append(triggers)
+
+    return {
+        "cardId": "sandstorm_home",
+        "card": {
+            "header": {
+                "title": "Sandstorm",
+                "subtitle": "AI agents in secure sandboxes",
+            },
+            "sections": sections,
+        },
+    }

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -23,8 +23,8 @@ def _verify_google_chat_jwt(auth_header: str) -> bool:
         logger.warning("GOOGLE_CHAT_PROJECT_NUMBER not set — cannot verify JWT")
         return False
     try:
-        from google.oauth2 import id_token
         from google.auth.transport import requests as google_requests
+        from google.oauth2 import id_token
 
         claim = id_token.verify_token(
             token,
@@ -88,9 +88,8 @@ async def _handle_card_clicked(body: dict) -> dict:
         user = body.get("user", {}).get("name", "")
         if run_id and sentiment:
             run_store.set_feedback(run_id, sentiment, user)
-        return {
-            "text": f"{'\U0001f44d' if sentiment == 'positive' else '\U0001f44e'} Feedback recorded. Thanks!"
-        }
+        emoji = "\U0001f44d" if sentiment == "positive" else "\U0001f44e"
+        return {"text": f"{emoji} Feedback recorded. Thanks!"}
 
     if method == "sandstorm_cancel_run":
         from .cancellation import request_cancellation
@@ -115,14 +114,13 @@ async def _handle_reaction(body: dict) -> dict:
     """Handle REACTION_ADDED events — match against triggers."""
     from .config import load_sandstorm_config
     from .gchat import unicode_to_shortcode
-    from .triggers import load_triggers, render_prompt
+    from .triggers import load_triggers
 
     emoji_unicode = body.get("reaction", {}).get("unicode", "")
     shortcode = unicode_to_shortcode(emoji_unicode)
     if not shortcode:
         return {}
 
-    message = body.get("message", {})
     space_name = body.get("space", {}).get("name", "")
 
     config = load_sandstorm_config()

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -55,6 +55,13 @@ async def _dispatch_event(body: dict) -> dict:
         space_name = body.get("space", {}).get("name", "")
         return dispatch_slash_command(body, team_id=space_name, user_id=user_name)
 
+    if event_type == "app_home":
+        from .gchat_app_home import build_home_card
+        user_name = body.get("user", {}).get("name", "")
+        space_name = body.get("space", {}).get("name", "")
+        card = build_home_card(team_id=space_name, user_id=user_name)
+        return {"cardsV2": [card]}
+
     if event_type == "card_clicked":
         return await _handle_card_clicked(body)
 
@@ -81,6 +88,22 @@ async def _handle_card_clicked(body: dict) -> dict:
         return {
             "text": f"{'\U0001f44d' if sentiment == 'positive' else '\U0001f44e'} Feedback recorded. Thanks!"
         }
+
+    if method == "sandstorm_cancel_run":
+        from .cancellation import request_cancellation
+        run_id = params.get("run_id", "")
+        if run_id:
+            request_cancellation(run_id)
+        return {"text": f"Cancelled run `{run_id}`."}
+
+    if method == "sandstorm_forget_memory":
+        from .memory import memory_store
+        memory_id = params.get("memory_id", "")
+        user = body.get("user", {}).get("name", "")
+        space = body.get("space", {}).get("name", "")
+        if memory_id:
+            memory_store.forget_by_id(memory_id, team_id=space, user_id=user, scope="user")
+        return {"text": "Memory forgotten."}
 
     return {}
 

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -93,9 +93,19 @@ async def _handle_card_clicked(body: dict) -> dict:
 
     if method == "sandstorm_cancel_run":
         from .cancellation import request_cancellation
+        from .store import run_store
+
         run_id = params.get("run_id", "")
-        if run_id:
-            request_cancellation(run_id)
+        user = body.get("user", {}).get("name", "")
+        space = body.get("space", {}).get("name", "")
+        if not run_id:
+            return {"text": "No run to cancel."}
+        run = run_store.get(run_id)
+        if run is None or run.team_id != space or run.user_id != user:
+            return {"text": "Run not found or not yours."}
+        if run.status != "running":
+            return {"text": f"Run `{run_id}` is already finished."}
+        request_cancellation(run_id)
         return {"text": f"Cancelled run `{run_id}`."}
 
     if method == "sandstorm_forget_memory":

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -65,6 +65,9 @@ async def _dispatch_event(body: dict) -> dict:
     if event_type == "card_clicked":
         return await _handle_card_clicked(body)
 
+    if event_type == "reaction_added":
+        return await _handle_reaction(body)
+
     # MESSAGE events (mention, dm_message) will be handled in a later task
     # when the full agent run pipeline is wired up.
 
@@ -106,6 +109,43 @@ async def _handle_card_clicked(body: dict) -> dict:
         return {"text": "Memory forgotten."}
 
     return {}
+
+
+async def _handle_reaction(body: dict) -> dict:
+    """Handle REACTION_ADDED events — match against triggers."""
+    from .config import load_sandstorm_config
+    from .gchat import unicode_to_shortcode
+    from .triggers import load_triggers, render_prompt
+
+    emoji_unicode = body.get("reaction", {}).get("unicode", "")
+    shortcode = unicode_to_shortcode(emoji_unicode)
+    if not shortcode:
+        return {}
+
+    message = body.get("message", {})
+    space_name = body.get("space", {}).get("name", "")
+
+    config = load_sandstorm_config()
+    if config is None:
+        return {}
+    try:
+        triggers = load_triggers(config)
+    except ValueError:
+        return {}
+
+    matches = [
+        t
+        for t in triggers
+        if t.type == "reaction"
+        and t.emoji == shortcode
+        and (not t.channels or space_name in t.channels)
+    ]
+    if not matches:
+        return {}
+
+    # Reaction triggers will fire agent runs in a future task
+    # For now, acknowledge the trigger match
+    return {"text": f"Trigger matched: {matches[0].name}"}
 
 
 @router.post("/gchat/events")

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -1,0 +1,66 @@
+"""Google Chat events endpoint for FastAPI."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Google Chat"])
+
+
+def _verify_google_chat_jwt(auth_header: str) -> bool:
+    """Verify the Bearer JWT from Google Chat."""
+    if not auth_header.startswith("Bearer "):
+        return False
+    token = auth_header[7:]
+    project_number = os.environ.get("GOOGLE_CHAT_PROJECT_NUMBER", "")
+    if not project_number:
+        logger.warning("GOOGLE_CHAT_PROJECT_NUMBER not set — cannot verify JWT")
+        return False
+    try:
+        from google.oauth2 import id_token
+        from google.auth.transport import requests as google_requests
+
+        claim = id_token.verify_token(
+            token,
+            google_requests.Request(),
+            audience=project_number,
+            certs_url="https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com",
+        )
+        return claim.get("iss") == "chat@system.gserviceaccount.com"
+    except Exception:
+        logger.warning("Google Chat JWT verification failed", exc_info=True)
+        return False
+
+
+async def _dispatch_event(body: dict) -> dict:
+    """Route a Google Chat event to the appropriate handler."""
+    event_type = body.get("type", "")
+
+    if event_type == "ADDED_TO_SPACE":
+        return {
+            "text": "Hi! I'm Sandstorm — I run general-purpose agent tasks in secure sandboxes. "
+            "Mention me or DM me with a task!"
+        }
+
+    return {}
+
+
+@router.post("/gchat/events")
+async def gchat_events(request: Request):
+    """Handle all Google Chat events."""
+    if not os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY"):
+        return JSONResponse({"error": "Google Chat not configured"}, status_code=503)
+
+    auth_header = request.headers.get("Authorization", "")
+    if not _verify_google_chat_jwt(auth_header):
+        return JSONResponse({"error": "invalid token"}, status_code=401)
+
+    body = await request.json()
+    result = await _dispatch_event(body)
+    return JSONResponse(result)

--- a/src/sandstorm/gchat_routes.py
+++ b/src/sandstorm/gchat_routes.py
@@ -40,12 +40,46 @@ def _verify_google_chat_jwt(auth_header: str) -> bool:
 
 async def _dispatch_event(body: dict) -> dict:
     """Route a Google Chat event to the appropriate handler."""
-    event_type = body.get("type", "")
+    from .gchat import dispatch_slash_command, parse_event_type
 
-    if event_type == "ADDED_TO_SPACE":
+    event_type = parse_event_type(body)
+
+    if event_type == "added_to_space":
         return {
             "text": "Hi! I'm Sandstorm — I run general-purpose agent tasks in secure sandboxes. "
             "Mention me or DM me with a task!"
+        }
+
+    if event_type == "slash_command":
+        user_name = body.get("user", {}).get("name", "")
+        space_name = body.get("space", {}).get("name", "")
+        return dispatch_slash_command(body, team_id=space_name, user_id=user_name)
+
+    if event_type == "card_clicked":
+        return await _handle_card_clicked(body)
+
+    # MESSAGE events (mention, dm_message) will be handled in a later task
+    # when the full agent run pipeline is wired up.
+
+    return {}
+
+
+async def _handle_card_clicked(body: dict) -> dict:
+    """Handle interactive card button clicks (e.g. feedback)."""
+    action = body.get("action", {})
+    method = action.get("actionMethodName", "")
+    params = {p["key"]: p["value"] for p in action.get("parameters", [])}
+
+    if method == "sandstorm_feedback":
+        from .store import run_store
+
+        run_id = params.get("run_id", "")
+        sentiment = params.get("sentiment", "")
+        user = body.get("user", {}).get("name", "")
+        if run_id and sentiment:
+            run_store.set_feedback(run_id, sentiment, user)
+        return {
+            "text": f"{'\U0001f44d' if sentiment == 'positive' else '\U0001f44e'} Feedback recorded. Thanks!"
         }
 
     return {}

--- a/src/sandstorm/main.py
+++ b/src/sandstorm/main.py
@@ -270,6 +270,14 @@ try:
 except ImportError:
     pass
 
+# Mount Google Chat events endpoint (requires `pip install "duvo-sandstorm[gchat]"`)
+try:
+    from .gchat_routes import router as gchat_router
+
+    app.include_router(gchat_router)
+except ImportError:
+    pass
+
 
 _DASHBOARD_HTML = (Path(__file__).parent / "dashboard.html").read_text()
 

--- a/src/sandstorm/platform.py
+++ b/src/sandstorm/platform.py
@@ -6,6 +6,7 @@ Google Chat, and future chat platform adapters.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from .models import QueryRequest
 
@@ -101,3 +102,54 @@ def unique_filename(name: str, seen: set[str]) -> str:
             seen.add(candidate)
             return candidate
     return name
+
+
+MAX_SANDBOX_POOL = 1000
+
+
+class SandboxPoolManager:
+    """Thread-safe sandbox reuse pool with LRU eviction."""
+
+    def __init__(self, max_size: int = MAX_SANDBOX_POOL):
+        self._max_size = max_size
+        self._pool: dict[tuple[str, str, str], tuple[str | None, asyncio.Lock]] = {}
+
+    async def get_or_create(
+        self, tenant: str, channel: str, thread_ts: str
+    ) -> tuple[str | None, asyncio.Lock]:
+        key = (tenant, channel, thread_ts)
+        if key not in self._pool:
+            self._pool[key] = (None, asyncio.Lock())
+        return self._pool[key]
+
+    def update(self, tenant: str, channel: str, thread_ts: str, sandbox_id: str | None) -> None:
+        key = (tenant, channel, thread_ts)
+        if key in self._pool:
+            _, lock = self._pool[key]
+            self._pool[key] = (sandbox_id, lock)
+
+    def clear(self, tenant: str, channel: str, thread_ts: str) -> None:
+        key = (tenant, channel, thread_ts)
+        if key in self._pool:
+            _, lock = self._pool[key]
+            self._pool[key] = (None, lock)
+
+    def set_initial(
+        self, tenant: str, channel: str, thread_ts: str, sandbox_id: str | None
+    ) -> None:
+        key = (tenant, channel, thread_ts)
+        if key not in self._pool:
+            self._pool[key] = (sandbox_id, asyncio.Lock())
+
+    def has_key(self, tenant: str, channel: str, thread_ts: str) -> bool:
+        return (tenant, channel, thread_ts) in self._pool
+
+    def evict_if_needed(self) -> None:
+        while len(self._pool) > self._max_size:
+            oldest_key = next(iter(self._pool))
+            evicted_id, _ = self._pool.pop(oldest_key)
+            if evicted_id:
+                logger.debug("Evicted sandbox %s from pool", evicted_id)
+
+    def size(self) -> int:
+        return len(self._pool)

--- a/src/sandstorm/platform.py
+++ b/src/sandstorm/platform.py
@@ -7,8 +7,16 @@ Google Chat, and future chat platform adapters.
 from __future__ import annotations
 
 import asyncio
+import base64
+import contextlib
+import json
 import logging
+import time
+from collections.abc import Callable
+
 from .models import QueryRequest
+from .sandbox import run_agent_in_sandbox
+from .store import build_config_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -153,3 +161,203 @@ class SandboxPoolManager:
 
     def size(self) -> int:
         return len(self._pool)
+
+
+class StreamBridge:
+    """Consume run_agent_in_sandbox() events and dispatch to a streamer.
+
+    The streamer must implement:
+      async append(*, markdown_text: str) -> None
+      async stop(blocks: list[dict] | None = None) -> None
+    """
+
+    def __init__(self, streamer, *, run_store):
+        self._streamer = streamer
+        self._run_store = run_store
+
+    async def run(
+        self,
+        request,
+        run_id: str,
+        client,
+        channel: str,
+        thread_ts: str,
+        set_status: Callable | None = None,
+        *,
+        keep_alive: bool = False,
+        sandbox_id: str | None = None,
+        sandbox_id_out: list[str] | None = None,
+        binary_files: dict[str, bytes] | None = None,
+        build_footer: Callable | None = None,
+        upload_file: Callable | None = None,
+    ) -> dict:
+        metadata: dict = {
+            "model": None, "cost_usd": None, "num_turns": None,
+            "duration_secs": None, "error": None, "agent_session_id": None,
+        }
+        start = time.monotonic()
+        stopped = False
+        has_streamed_text = False
+
+        self._run_store.create(
+            id=run_id,
+            prompt=request.prompt,
+            model=request.model,
+            files_count=len(request.files) if request.files else 0,
+            raw_prompt=request.prompt,
+            team_id=request.team_id,
+            user_id=request.user_id,
+            channel_id=channel,
+            thread_ts=thread_ts,
+            sandbox_id=sandbox_id,
+            config_snapshot=build_config_snapshot({
+                "model": request.model,
+                "allowed_tools": request.allowed_tools,
+                "timeout": request.timeout,
+                "files": request.files,
+            }),
+        )
+
+        try:
+            async for line in run_agent_in_sandbox(
+                request, run_id, keep_alive=keep_alive,
+                sandbox_id=sandbox_id, sandbox_id_out=sandbox_id_out,
+                binary_files=binary_files,
+            ):
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+
+                event_type = event.get("type")
+                logger.info("[%s] Event: %s", run_id, event_type)
+
+                if event_type == "system" and event.get("subtype") == "init":
+                    model = event.get("model")
+                    metadata["model"] = model
+                    metadata["agent_session_id"] = (
+                        event.get("session_id") or metadata["agent_session_id"]
+                    )
+                    if set_status:
+                        await set_status(f"Running agent on {model}...")
+
+                elif event_type == "assistant":
+                    message = event.get("message", {})
+                    for block in message.get("content", []):
+                        if block.get("type") == "text":
+                            text = block["text"]
+                            if text:
+                                prefix = "\n\n" if has_streamed_text else ""
+                                try:
+                                    await self._streamer.append(markdown_text=prefix + text)
+                                    has_streamed_text = True
+                                    logger.info("[%s] Streamed %d chars", run_id, len(text))
+                                except Exception:
+                                    logger.error("[%s] streamer.append failed", run_id, exc_info=True)
+                        elif block.get("type") == "tool_use":
+                            tool_name = block.get("name", "unknown")
+                            logger.info("[%s] Tool: %s", run_id, tool_name)
+                            if set_status:
+                                await set_status(f"Using {tool_name}...")
+                            else:
+                                try:
+                                    await self._streamer.append(
+                                        markdown_text=f"\n_:hammer_and_wrench: {tool_name}_\n"
+                                    )
+                                    has_streamed_text = True
+                                except Exception:
+                                    logger.error(
+                                        "[%s] streamer.append (tool crumb) failed",
+                                        run_id, exc_info=True,
+                                    )
+
+                elif event_type == "result":
+                    cost = event.get("total_cost_usd")
+                    metadata["cost_usd"] = cost if cost is not None else event.get("cost_usd")
+                    metadata["num_turns"] = event.get("num_turns")
+                    metadata["duration_secs"] = round(time.monotonic() - start, 1)
+                    metadata["model"] = event.get("model") or metadata["model"]
+                    logger.info(
+                        "[%s] Result: turns=%s cost=%s",
+                        run_id, metadata["num_turns"], metadata["cost_usd"],
+                    )
+
+                    footer_blocks = build_footer(run_id, metadata) if build_footer else None
+                    try:
+                        await self._streamer.stop(blocks=footer_blocks)
+                        stopped = True
+                        logger.info("[%s] Stream stopped with footer", run_id)
+                    except Exception:
+                        logger.error("[%s] streamer.stop failed", run_id, exc_info=True)
+
+                    metadata["agent_session_id"] = (
+                        event.get("session_id") or metadata["agent_session_id"]
+                    )
+                    if metadata["agent_session_id"] is None:
+                        logger.info(
+                            "[%s] No agent_session_id captured — next thread message "
+                            "will not resume the session",
+                            run_id,
+                        )
+                    self._run_store.complete(
+                        run_id,
+                        cost_usd=metadata["cost_usd"],
+                        num_turns=metadata["num_turns"],
+                        duration_secs=metadata["duration_secs"],
+                        model=metadata["model"],
+                        agent_session_id=metadata["agent_session_id"],
+                    )
+
+                elif event_type == "error":
+                    error_msg = event.get("error", "Unknown error")
+                    metadata["error"] = error_msg
+                    metadata["duration_secs"] = round(time.monotonic() - start, 1)
+                    logger.error("[%s] Agent error: %s", run_id, error_msg)
+
+                    try:
+                        await self._streamer.append(markdown_text=f"\n:warning: Error: {error_msg}")
+                        await self._streamer.stop()
+                        stopped = True
+                    except Exception:
+                        logger.error("[%s] streamer.stop (error) failed", run_id, exc_info=True)
+
+                    self._run_store.fail(run_id, error_msg, metadata["duration_secs"])
+
+                elif event_type == "file":
+                    file_name = event.get("name", "file")
+                    file_title = event.get("relative_path") or file_name
+                    file_data_b64 = event.get("data")
+                    if file_data_b64 and upload_file:
+                        try:
+                            file_data = base64.b64decode(file_data_b64)
+                            await upload_file(
+                                channel=channel,
+                                thread_ts=thread_ts,
+                                content=file_data,
+                                filename=file_name,
+                                title=file_title,
+                            )
+                            logger.info(
+                                "[%s] Uploaded file %s (%d bytes)",
+                                run_id, file_title, len(file_data),
+                            )
+                        except Exception:
+                            logger.error(
+                                "[%s] Failed to upload %s",
+                                run_id, file_name, exc_info=True,
+                            )
+
+                elif event_type in ("user", "stderr", "warning"):
+                    logger.debug("[%s] %s", run_id, event_type)
+
+        except Exception as exc:
+            metadata["error"] = str(exc)
+            metadata["duration_secs"] = round(time.monotonic() - start, 1)
+            logger.error("[%s] Stream error: %s", run_id, exc, exc_info=True)
+            self._run_store.fail(run_id, str(exc), metadata["duration_secs"])
+        finally:
+            if not stopped:
+                with contextlib.suppress(Exception):
+                    await self._streamer.stop()
+
+        return metadata

--- a/src/sandstorm/platform.py
+++ b/src/sandstorm/platform.py
@@ -253,7 +253,9 @@ class StreamBridge:
                                     has_streamed_text = True
                                     logger.info("[%s] Streamed %d chars", run_id, len(text))
                                 except Exception:
-                                    logger.error("[%s] streamer.append failed", run_id, exc_info=True)
+                                    logger.error(
+                                        "[%s] streamer.append failed", run_id, exc_info=True
+                                    )
                         elif block.get("type") == "tool_use":
                             tool_name = block.get("name", "unknown")
                             logger.info("[%s] Tool: %s", run_id, tool_name)
@@ -315,7 +317,8 @@ class StreamBridge:
                     logger.error("[%s] Agent error: %s", run_id, error_msg)
 
                     try:
-                        await self._streamer.append(markdown_text=f"\n:warning: Error: {error_msg}")
+                        err_text = f"\n:warning: Error: {error_msg}"
+                        await self._streamer.append(markdown_text=err_text)
                         await self._streamer.stop()
                         stopped = True
                     except Exception:

--- a/src/sandstorm/platform.py
+++ b/src/sandstorm/platform.py
@@ -1,0 +1,103 @@
+"""Shared platform-agnostic core for chat integrations.
+
+Contains utilities, protocols, and orchestration shared across Slack,
+Google Chat, and future chat platform adapters.
+"""
+
+from __future__ import annotations
+
+import logging
+from .models import QueryRequest
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE = 50 * 1024 * 1024
+
+BINARY_MIME_PREFIXES = (
+    "image/",
+    "audio/",
+    "video/",
+    "application/pdf",
+    "application/zip",
+    "application/vnd.openxmlformats-",
+    "application/vnd.ms-",
+    "application/msword",
+    "application/x-7z-compressed",
+    "application/x-rar-compressed",
+    "application/x-tar",
+    "application/gzip",
+    "application/octet-stream",
+)
+
+
+def build_query_request(
+    prompt: str,
+    files: dict[str, str] | None = None,
+    team_id: str | None = None,
+    user_id: str | None = None,
+    model: str | None = None,
+    channel_id: str | None = None,
+) -> QueryRequest:
+    """Build QueryRequest from prompt, deferring model/timeout to sandstorm.json."""
+    return QueryRequest(
+        prompt=prompt,
+        model=model,
+        timeout=None,
+        files=files,
+        output_format={},
+        anthropic_api_key=None,
+        e2b_api_key=None,
+        openrouter_api_key=None,
+        max_turns=None,
+        team_id=team_id,
+        user_id=user_id,
+        channel_id=channel_id,
+    )
+
+
+def gather_thread_context(
+    messages: list[dict],
+    bot_user_id: str,
+    *,
+    user_names: dict[str, str] | None = None,
+) -> str:
+    """Format thread messages into a context string."""
+    lines: list[str] = []
+    for msg in messages:
+        user = msg.get("user", "unknown")
+        text = msg.get("text", "").strip()
+
+        if user == bot_user_id:
+            if text:
+                lines.append(f"[Sandstorm] {text}")
+            continue
+
+        display = user_names.get(user, user) if user_names else user
+
+        if text:
+            lines.append(f"[{display}] {text}")
+
+        for f in msg.get("files", []):
+            name = f.get("name", "unknown")
+            mimetype = f.get("mimetype", "unknown")
+            size = f.get("size", 0)
+            size_kb = size / 1024
+            lines.append(f"[{display}] [attached: {name} ({mimetype}, {size_kb:.0f}KB)]")
+
+    return "\n".join(lines)
+
+
+def unique_filename(name: str, seen: set[str]) -> str:
+    """Return a unique filename, appending _1, _2, etc. for duplicates."""
+    if name not in seen:
+        seen.add(name)
+        return name
+    stem, dot, ext = name.rpartition(".")
+    if not dot:
+        stem, ext = name, ""
+    for i in range(1, 100):
+        candidate = f"{stem}_{i}.{ext}" if ext else f"{stem}_{i}"
+        if candidate not in seen:
+            seen.add(candidate)
+            return candidate
+    return name

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -20,6 +20,7 @@ from .store import build_config_snapshot, run_store
 from .platform import (
     BINARY_MIME_PREFIXES as _BINARY_MIME_PREFIXES,
     MAX_FILE_SIZE as _MAX_FILE_SIZE,
+    SandboxPoolManager,
     build_query_request as _build_query_request,
     gather_thread_context as _gather_thread_context,
     unique_filename as _unique_filename,
@@ -29,9 +30,6 @@ if TYPE_CHECKING:
     from slack_bolt.async_app import AsyncApp
 
 logger = logging.getLogger(__name__)
-
-# Max sandbox pool entries (one per active thread)
-_MAX_SANDBOX_POOL = 1000
 
 
 # ── Metadata blocks ──────────────────────────────────────────────────────────
@@ -454,7 +452,7 @@ def create_slack_app(
 
     # Sandbox reuse pool: (team_id, channel, thread_ts) -> (sandbox_id, lock).
     # Lock serializes concurrent @mentions in the same thread.
-    _sandbox_pool: dict[tuple[str, str, str], tuple[str | None, asyncio.Lock]] = {}
+    _sandbox_pool = SandboxPoolManager()
 
     # Per-user-per-channel model override from /model. In-memory only:
     # intentionally lost on restart so overrides don't outlive the process.
@@ -528,19 +526,17 @@ def create_slack_app(
     ) -> dict:
         """Run agent with sandbox reuse, pool management, and eviction."""
         tenant = context.get("enterprise_id") or context.get("team_id") or ""
-        key = (tenant, channel, thread_ts)
-        if key not in _sandbox_pool:
-            # Cold start (or server restart). Look up the prior Run for this
-            # thread and resume its paused sandbox if it still exists; E2B's
-            # connect() auto-resumes. On failure the generic reuse-error path
-            # handles the fallback.
+
+        if not _sandbox_pool.has_key(tenant, channel, thread_ts):
             prior = run_store.find_thread_session(tenant, channel, thread_ts)
             initial_id = prior.sandbox_id if prior else None
-            _sandbox_pool[key] = (initial_id, asyncio.Lock())
-        _, lock = _sandbox_pool[key]
+            _sandbox_pool.set_initial(tenant, channel, thread_ts, initial_id)
+
+        existing_sandbox_id, lock = await _sandbox_pool.get_or_create(tenant, channel, thread_ts)
 
         async with lock:
-            existing_sandbox_id = _sandbox_pool[key][0]
+            # Re-read after acquiring lock (another coroutine may have updated it)
+            existing_sandbox_id, _ = await _sandbox_pool.get_or_create(tenant, channel, thread_ts)
             sandbox_id_out: list[str] = []
             reuse_succeeded = False
             if existing_sandbox_id:
@@ -570,7 +566,7 @@ def create_slack_app(
                 )
                 reuse_succeeded = not metadata.get("error")
                 if not reuse_succeeded:
-                    _sandbox_pool[key] = (None, lock)
+                    _sandbox_pool.clear(tenant, channel, thread_ts)
                     logger.warning(
                         "[%s] Sandbox %s failed, creating new",
                         run_id,
@@ -602,18 +598,10 @@ def create_slack_app(
                     binary_files=binary_files or None,
                 )
                 new_id = sandbox_id_out[0] if sandbox_id_out else None
-                _sandbox_pool.pop(key, None)
-                _sandbox_pool[key] = (new_id, lock)
+                _sandbox_pool.update(tenant, channel, thread_ts, new_id)
 
         # Evict oldest entries if pool is too large
-        while len(_sandbox_pool) > _MAX_SANDBOX_POOL:
-            oldest_key = next(iter(_sandbox_pool))
-            evicted_id, _ = _sandbox_pool.pop(oldest_key)
-            if evicted_id:
-                logger.debug(
-                    "Evicted sandbox %s from pool (will auto-expire)",
-                    evicted_id,
-                )
+        _sandbox_pool.evict_if_needed()
 
         return metadata
 

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -15,37 +15,23 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from .memory import memory_store
-from .models import QueryRequest
 from .sandbox import run_agent_in_sandbox
 from .store import build_config_snapshot, run_store
+from .platform import (
+    BINARY_MIME_PREFIXES as _BINARY_MIME_PREFIXES,
+    MAX_FILE_SIZE as _MAX_FILE_SIZE,
+    build_query_request as _build_query_request,
+    gather_thread_context as _gather_thread_context,
+    unique_filename as _unique_filename,
+)
 
 if TYPE_CHECKING:
     from slack_bolt.async_app import AsyncApp
 
 logger = logging.getLogger(__name__)
 
-# Max file size to download from Slack threads (50 MB)
-_MAX_FILE_SIZE = 50 * 1024 * 1024
-
 # Max sandbox pool entries (one per active thread)
 _MAX_SANDBOX_POOL = 1000
-
-# MIME prefixes treated as binary (downloaded as bytes, not text)
-_BINARY_MIME_PREFIXES = (
-    "image/",
-    "audio/",
-    "video/",
-    "application/pdf",
-    "application/zip",
-    "application/vnd.openxmlformats-",  # .xlsx, .docx, .pptx
-    "application/vnd.ms-",  # legacy .xls, .doc, .ppt
-    "application/msword",  # legacy .doc alternative
-    "application/x-7z-compressed",
-    "application/x-rar-compressed",
-    "application/x-tar",
-    "application/gzip",
-    "application/octet-stream",  # generic binary fallback
-)
 
 
 # ── Metadata blocks ──────────────────────────────────────────────────────────
@@ -97,41 +83,6 @@ def _build_metadata_blocks(
         }
     )
     return blocks
-
-
-# ── Query builder ─────────────────────────────────────────────────────────────
-
-
-def _build_query_request(
-    prompt: str,
-    files: dict[str, str] | None = None,
-    team_id: str | None = None,
-    user_id: str | None = None,
-    model: str | None = None,
-    channel_id: str | None = None,
-) -> QueryRequest:
-    """Build QueryRequest from prompt, deferring model/timeout to sandstorm.json.
-
-    When team_id/user_id/channel_id are passed, the server-side memory
-    injection in config._build_agent_config scopes the three-level memory
-    (team + channel + user) appropriately.
-
-    API keys resolved by QueryRequest.resolve_api_keys() as usual.
-    """
-    return QueryRequest(
-        prompt=prompt,
-        model=model,
-        timeout=None,
-        files=files,
-        output_format={},  # Slack is conversational — skip structured output
-        anthropic_api_key=None,
-        e2b_api_key=None,
-        openrouter_api_key=None,
-        max_turns=None,
-        team_id=team_id,
-        user_id=user_id,
-        channel_id=channel_id,
-    )
 
 
 # ── Thread helpers ────────────────────────────────────────────────────────────
@@ -186,63 +137,7 @@ async def _resolve_user_names(client, messages: list[dict], bot_user_id: str) ->
     return dict(results)
 
 
-def _gather_thread_context(
-    messages: list[dict], bot_user_id: str, *, user_names: dict[str, str] | None = None
-) -> str:
-    """Format thread messages into a context string.
-
-    Includes bot's own messages (prefixed [Sandstorm]) for conversational
-    continuity. Includes file names/types for user messages.
-    Returns formatted string like:
-      [Alice] Hey, this CSV has duplicate rows...
-      [Alice] [attached: data.csv (text/csv, 15KB)]
-      [Bob] @Sandstorm deduplicate this CSV...
-      [Sandstorm] Here's my analysis of the data...
-    """
-    lines: list[str] = []
-    for msg in messages:
-        user = msg.get("user", "unknown")
-        text = msg.get("text", "").strip()
-
-        # Include bot's own messages for conversational continuity
-        if user == bot_user_id:
-            if text:
-                lines.append(f"[Sandstorm] {text}")
-            continue  # skip file attachments from bot
-
-        display = user_names.get(user, user) if user_names else user
-
-        if text:
-            lines.append(f"[{display}] {text}")
-
-        # Note attached files
-        for f in msg.get("files", []):
-            name = f.get("name", "unknown")
-            mimetype = f.get("mimetype", "unknown")
-            size = f.get("size", 0)
-            size_kb = size / 1024
-            lines.append(f"[{display}] [attached: {name} ({mimetype}, {size_kb:.0f}KB)]")
-
-    return "\n".join(lines)
-
-
 # ── File handling ─────────────────────────────────────────────────────────────
-
-
-def _unique_filename(name: str, seen: set[str]) -> str:
-    """Return a unique filename, appending _1, _2, etc. for duplicates."""
-    if name not in seen:
-        seen.add(name)
-        return name
-    stem, dot, ext = name.rpartition(".")
-    if not dot:
-        stem, ext = name, ""
-    for i in range(1, 100):
-        candidate = f"{stem}_{i}.{ext}" if ext else f"{stem}_{i}"
-        if candidate not in seen:
-            seen.add(candidate)
-            return candidate
-    return name  # fallback
 
 
 async def _download_thread_files(

--- a/src/sandstorm/slack.py
+++ b/src/sandstorm/slack.py
@@ -3,24 +3,21 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
-import json
 import logging
 import os
 import re
-import time
 import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from .memory import memory_store
-from .sandbox import run_agent_in_sandbox
-from .store import build_config_snapshot, run_store
+from .store import run_store
 from .platform import (
     BINARY_MIME_PREFIXES as _BINARY_MIME_PREFIXES,
     MAX_FILE_SIZE as _MAX_FILE_SIZE,
     SandboxPoolManager,
+    StreamBridge,
     build_query_request as _build_query_request,
     gather_thread_context as _gather_thread_context,
     unique_filename as _unique_filename,
@@ -224,210 +221,31 @@ async def _stream_to_slack(
     sandbox_id_out: list[str] | None = None,
     binary_files: dict[str, bytes] | None = None,
 ) -> dict:
-    """Core bridge: consume run_agent_in_sandbox() -> stream to Slack.
+    """Core bridge: consume run_agent_in_sandbox() -> stream to Slack."""
 
-    Args:
-        streamer: Chat stream object from client.chat_stream()
-        set_status: Optional async callable (only in Assistant context).
-        Returns metadata dict {model, cost_usd, num_turns, duration_secs, error}.
-    """
-    metadata: dict = {
-        "model": None,
-        "cost_usd": None,
-        "num_turns": None,
-        "duration_secs": None,
-        "error": None,
-        "agent_session_id": None,
-    }
+    def _build_footer(run_id: str, metadata: dict) -> list[dict]:
+        return _build_metadata_blocks(
+            run_id, metadata["model"], metadata["cost_usd"],
+            metadata["num_turns"], metadata["duration_secs"],
+        )
 
-    start = time.monotonic()
-    stopped = False
-    has_streamed_text = False
+    async def _upload_file(*, channel, thread_ts, content, filename, title):
+        await client.files_upload_v2(
+            channel=channel, thread_ts=thread_ts,
+            content=content, filename=filename, title=title,
+        )
 
-    run_store.create(
-        id=run_id,
-        prompt=request.prompt,
-        model=request.model,
-        files_count=len(request.files) if request.files else 0,
-        raw_prompt=request.prompt,
-        team_id=request.team_id,
-        user_id=request.user_id,
-        channel_id=channel,
-        thread_ts=thread_ts,
+    bridge = StreamBridge(streamer, run_store=run_store)
+    return await bridge.run(
+        request, run_id, client, channel, thread_ts,
+        set_status=set_status,
+        keep_alive=keep_alive,
         sandbox_id=sandbox_id,
-        config_snapshot=build_config_snapshot(
-            {
-                "model": request.model,
-                "allowed_tools": request.allowed_tools,
-                "timeout": request.timeout,
-                "files": request.files,
-            }
-        ),
+        sandbox_id_out=sandbox_id_out,
+        binary_files=binary_files,
+        build_footer=_build_footer,
+        upload_file=_upload_file,
     )
-
-    try:
-        async for line in run_agent_in_sandbox(
-            request,
-            run_id,
-            keep_alive=keep_alive,
-            sandbox_id=sandbox_id,
-            sandbox_id_out=sandbox_id_out,
-            binary_files=binary_files,
-        ):
-            try:
-                event = json.loads(line)
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            event_type = event.get("type")
-            logger.info("[%s] Event: %s", run_id, event_type)
-
-            if event_type == "system" and event.get("subtype") == "init":
-                model = event.get("model")
-                metadata["model"] = model
-                # Captured so the next message in this thread can resume the session
-                metadata["agent_session_id"] = (
-                    event.get("session_id") or metadata["agent_session_id"]
-                )
-                if set_status:
-                    await set_status(f"Running agent on {model}...")
-
-            elif event_type == "assistant":
-                message = event.get("message", {})
-                for block in message.get("content", []):
-                    if block.get("type") == "text":
-                        text = block["text"]
-                        if text:
-                            prefix = "\n\n" if has_streamed_text else ""
-                            try:
-                                await streamer.append(markdown_text=prefix + text)
-                                has_streamed_text = True
-                                logger.info("[%s] Streamed %d chars", run_id, len(text))
-                            except Exception:
-                                logger.error("[%s] streamer.append failed", run_id, exc_info=True)
-                    elif block.get("type") == "tool_use":
-                        tool_name = block.get("name", "unknown")
-                        logger.info("[%s] Tool: %s", run_id, tool_name)
-                        if set_status:
-                            await set_status(f"Using {tool_name}...")
-                        else:
-                            try:
-                                await streamer.append(
-                                    markdown_text=f"\n_:hammer_and_wrench: {tool_name}_\n"
-                                )
-                                has_streamed_text = True
-                            except Exception:
-                                logger.error(
-                                    "[%s] streamer.append (tool crumb) failed",
-                                    run_id,
-                                    exc_info=True,
-                                )
-
-            elif event_type == "result":
-                cost = event.get("total_cost_usd")
-                metadata["cost_usd"] = cost if cost is not None else event.get("cost_usd")
-                metadata["num_turns"] = event.get("num_turns")
-                metadata["duration_secs"] = round(time.monotonic() - start, 1)
-                metadata["model"] = event.get("model") or metadata["model"]
-                logger.info(
-                    "[%s] Result: turns=%s cost=%s",
-                    run_id,
-                    metadata["num_turns"],
-                    metadata["cost_usd"],
-                )
-
-                footer_blocks = _build_metadata_blocks(
-                    run_id,
-                    metadata["model"],
-                    metadata["cost_usd"],
-                    metadata["num_turns"],
-                    metadata["duration_secs"],
-                )
-                try:
-                    await streamer.stop(blocks=footer_blocks)
-                    stopped = True
-                    logger.info("[%s] Stream stopped with footer", run_id)
-                except Exception:
-                    logger.error("[%s] streamer.stop failed", run_id, exc_info=True)
-
-                # Some SDK versions also surface session_id on the result event
-                metadata["agent_session_id"] = (
-                    event.get("session_id") or metadata["agent_session_id"]
-                )
-                if metadata["agent_session_id"] is None:
-                    logger.info(
-                        "[%s] No agent_session_id captured — next thread message "
-                        "will not resume the session",
-                        run_id,
-                    )
-                run_store.complete(
-                    run_id,
-                    cost_usd=metadata["cost_usd"],
-                    num_turns=metadata["num_turns"],
-                    duration_secs=metadata["duration_secs"],
-                    model=metadata["model"],
-                    agent_session_id=metadata["agent_session_id"],
-                )
-
-            elif event_type == "error":
-                error_msg = event.get("error", "Unknown error")
-                metadata["error"] = error_msg
-                metadata["duration_secs"] = round(time.monotonic() - start, 1)
-                logger.error("[%s] Agent error: %s", run_id, error_msg)
-
-                try:
-                    await streamer.append(markdown_text=f"\n:warning: Error: {error_msg}")
-                    await streamer.stop()
-                    stopped = True
-                except Exception:
-                    logger.error("[%s] streamer.stop (error) failed", run_id, exc_info=True)
-
-                run_store.fail(run_id, error_msg, metadata["duration_secs"])
-
-            elif event_type == "file":
-                file_name = event.get("name", "file")
-                file_title = event.get("relative_path") or file_name
-                file_data_b64 = event.get("data")
-                if file_data_b64:
-                    try:
-                        file_data = base64.b64decode(file_data_b64)
-                        await client.files_upload_v2(
-                            channel=channel,
-                            thread_ts=thread_ts,
-                            content=file_data,
-                            filename=file_name,
-                            title=file_title,
-                        )
-                        logger.info(
-                            "[%s] Uploaded file %s (%d bytes)",
-                            run_id,
-                            file_title,
-                            len(file_data),
-                        )
-                    except Exception:
-                        logger.error(
-                            "[%s] Failed to upload %s to Slack",
-                            run_id,
-                            file_name,
-                            exc_info=True,
-                        )
-
-            # Skip user, stderr, warning events (log server-side only)
-            elif event_type in ("user", "stderr", "warning"):
-                logger.debug("[%s] %s", run_id, event_type)
-
-    except Exception as exc:
-        metadata["error"] = str(exc)
-        metadata["duration_secs"] = round(time.monotonic() - start, 1)
-        logger.error("[%s] Stream error: %s", run_id, exc, exc_info=True)
-        run_store.fail(run_id, str(exc), metadata["duration_secs"])
-    finally:
-        # Always stop the streamer to avoid dangling streams in Slack
-        if not stopped:
-            with contextlib.suppress(Exception):
-                await streamer.stop()
-
-    return metadata
 
 
 # ── App factory ───────────────────────────────────────────────────────────────

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1015,3 +1015,24 @@ class TestReplay:
         assert "Replay report" in result.output
         assert "orig-1" in result.output
         assert "claude-haiku-4-5-20251001" in result.output
+
+
+class TestGChatCLI:
+    def test_gchat_group_exists(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["gchat", "--help"])
+        assert result.exit_code == 0
+        assert "setup" in result.output
+        assert "start" in result.output
+        assert "verify" in result.output
+        assert "test" in result.output
+
+    def test_gchat_verify_without_config(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test")
+        monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["gchat", "verify"])
+        assert result.exit_code != 0

--- a/tests/test_gchat.py
+++ b/tests/test_gchat.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sandstorm.gchat import GChatStreamer
+from sandstorm.gchat import (
+    GChatStreamer,
+    build_metadata_cards,
+    dispatch_slash_command,
+    parse_event_type,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -56,3 +61,117 @@ class TestGChatStreamer:
         cards = [{"cardId": "meta", "card": {"sections": []}}]
         asyncio.run(streamer.stop(blocks=cards))
         assert streamer._accumulated == "Done"
+
+
+class TestParseEventType:
+    def test_added_to_space(self):
+        assert parse_event_type({"type": "ADDED_TO_SPACE"}) == "added_to_space"
+
+    def test_message_with_slash_command(self):
+        body = {"type": "MESSAGE", "message": {"slashCommand": {"commandId": "1"}}}
+        assert parse_event_type(body) == "slash_command"
+
+    def test_message_in_dm(self):
+        body = {"type": "MESSAGE", "space": {"type": "DM"}, "message": {"text": "hi"}}
+        assert parse_event_type(body) == "dm_message"
+
+    def test_message_with_mention(self):
+        body = {"type": "MESSAGE", "space": {"type": "ROOM"}, "message": {"text": "@bot help"}}
+        assert parse_event_type(body) == "mention"
+
+    def test_card_clicked(self):
+        body = {"type": "CARD_CLICKED", "action": {"actionMethodName": "feedback"}}
+        assert parse_event_type(body) == "card_clicked"
+
+    def test_app_home(self):
+        assert parse_event_type({"type": "APP_HOME"}) == "app_home"
+
+    def test_reaction_added(self):
+        assert parse_event_type({"type": "REACTION_ADDED"}) == "reaction_added"
+
+    def test_unknown(self):
+        assert parse_event_type({"type": "SOMETHING_ELSE"}) == "unknown"
+
+
+class TestBuildMetadataCards:
+    def test_returns_cards_v2_format(self):
+        cards = build_metadata_cards("run1", "sonnet", 0.01, 3, 12.5)
+        assert isinstance(cards, list)
+        assert len(cards) > 0
+        assert "cardId" in cards[0]
+        assert "card" in cards[0]
+
+    def test_includes_feedback_buttons(self):
+        cards = build_metadata_cards("run1", "sonnet", 0.01, 3, 12.5)
+        sections = cards[0]["card"]["sections"]
+        buttons_found = False
+        for section in sections:
+            for widget in section.get("widgets", []):
+                if "buttonList" in widget:
+                    buttons_found = True
+                    buttons = widget["buttonList"]["buttons"]
+                    assert len(buttons) == 2
+        assert buttons_found
+
+    def test_includes_metadata_text(self):
+        cards = build_metadata_cards("run1", "sonnet", 0.01, 3, 12.5)
+        sections = cards[0]["card"]["sections"]
+        text_found = False
+        for section in sections:
+            for widget in section.get("widgets", []):
+                if "textParagraph" in widget:
+                    text = widget["textParagraph"]["text"]
+                    assert "sonnet" in text
+                    assert "0.0100" in text
+                    text_found = True
+        assert text_found
+
+
+class TestDispatchSlashCommand:
+    def test_remember_command(self, tmp_path):
+        from sandstorm.memory import MemoryStore
+
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        body = {
+            "message": {"slashCommand": {"commandId": "1"}, "argumentText": "likes coffee"},
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat.memory_store", store):
+            result = dispatch_slash_command(body, team_id="T1", user_id="U1")
+        assert "Remembered" in result["text"]
+
+    def test_memories_command_empty(self, tmp_path):
+        from sandstorm.memory import MemoryStore
+
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        body = {
+            "message": {"slashCommand": {"commandId": "5"}, "argumentText": ""},
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat.memory_store", store):
+            result = dispatch_slash_command(body, team_id="T1", user_id="U1")
+        assert "No memories" in result["text"]
+
+    def test_forget_command_no_match(self, tmp_path):
+        from sandstorm.memory import MemoryStore
+
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        body = {
+            "message": {"slashCommand": {"commandId": "4"}, "argumentText": "nonexistent"},
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat.memory_store", store):
+            result = dispatch_slash_command(body, team_id="T1", user_id="U1")
+        assert "No memory matched" in result["text"]
+
+    def test_unknown_command(self):
+        body = {
+            "message": {"slashCommand": {"commandId": "99"}, "argumentText": ""},
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        result = dispatch_slash_command(body, team_id="T1", user_id="U1")
+        assert "Unknown" in result["text"]

--- a/tests/test_gchat.py
+++ b/tests/test_gchat.py
@@ -214,3 +214,17 @@ class TestGChatThreadContext:
         result = gather_thread_context(messages, "BOT_ID")
         assert "[users/123] Help with this" in result
         assert "[Sandstorm] Working on it..." in result
+
+
+from sandstorm.gchat import unicode_to_shortcode
+
+
+class TestEmojiNormalization:
+    def test_common_emoji_mapping(self):
+        assert unicode_to_shortcode("\U0001f440") == "eyes"
+        assert unicode_to_shortcode("\U0001f44d") == "+1"
+        assert unicode_to_shortcode("\U0001f44e") == "-1"
+        assert unicode_to_shortcode("\U0001f680") == "rocket"
+
+    def test_unknown_emoji_returns_none(self):
+        assert unicode_to_shortcode("\U0001f999") is None

--- a/tests/test_gchat.py
+++ b/tests/test_gchat.py
@@ -175,3 +175,23 @@ class TestDispatchSlashCommand:
         }
         result = dispatch_slash_command(body, team_id="T1", user_id="U1")
         assert "Unknown" in result["text"]
+
+
+from sandstorm.gchat_app_home import build_home_card
+
+
+class TestGChatAppHome:
+    def test_builds_valid_card(self):
+        card = build_home_card(team_id="T1", user_id="U1")
+        assert "cardId" in card
+        assert "card" in card
+
+    def test_includes_header(self):
+        card = build_home_card(team_id="T1", user_id="U1")
+        header = card["card"].get("header", {})
+        assert "Sandstorm" in header.get("title", "")
+
+    def test_has_sections(self):
+        card = build_home_card(team_id="T1", user_id="U1")
+        sections = card["card"].get("sections", [])
+        assert len(sections) >= 1

--- a/tests/test_gchat.py
+++ b/tests/test_gchat.py
@@ -195,3 +195,22 @@ class TestGChatAppHome:
         card = build_home_card(team_id="T1", user_id="U1")
         sections = card["card"].get("sections", [])
         assert len(sections) >= 1
+
+
+class TestGChatFileDownload:
+    def test_classifies_binary_files(self):
+        from sandstorm.platform import BINARY_MIME_PREFIXES
+        assert any("image/png".startswith(p) for p in BINARY_MIME_PREFIXES)
+        assert not any("text/plain".startswith(p) for p in BINARY_MIME_PREFIXES)
+
+
+class TestGChatThreadContext:
+    def test_fetch_and_format_thread(self):
+        from sandstorm.platform import gather_thread_context
+        messages = [
+            {"user": "users/123", "text": "Help with this"},
+            {"user": "BOT_ID", "text": "Working on it..."},
+        ]
+        result = gather_thread_context(messages, "BOT_ID")
+        assert "[users/123] Help with this" in result
+        assert "[Sandstorm] Working on it..." in result

--- a/tests/test_gchat.py
+++ b/tests/test_gchat.py
@@ -1,0 +1,58 @@
+"""Tests for the Google Chat adapter."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandstorm.gchat import GChatStreamer
+
+
+@pytest.fixture(autouse=True)
+def _set_required_env_vars(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+
+class TestGChatStreamer:
+    def test_append_buffers_text(self):
+        service = MagicMock()
+        streamer = GChatStreamer(service, "spaces/test", "spaces/test/messages/123", "thread-1")
+        asyncio.run(streamer.append(markdown_text="Hello "))
+        asyncio.run(streamer.append(markdown_text="world"))
+        assert streamer._buffer == "Hello world"
+
+    def test_flush_on_interval(self):
+        service = MagicMock()
+        execute_mock = MagicMock()
+        service.spaces().messages().update().execute = execute_mock
+        streamer = GChatStreamer(service, "spaces/test", "spaces/test/messages/123", "thread-1")
+        streamer._last_update = time.monotonic() - 3.0  # pretend 3s ago
+
+        asyncio.run(streamer.append(markdown_text="Hello"))
+        # Should have flushed because >2s since last update
+        assert streamer._accumulated == "Hello"
+        assert streamer._buffer == ""
+
+    def test_stop_flushes_remaining(self):
+        service = MagicMock()
+        execute_mock = MagicMock()
+        service.spaces().messages().update().execute = execute_mock
+        streamer = GChatStreamer(service, "spaces/test", "spaces/test/messages/123", "thread-1")
+
+        asyncio.run(streamer.append(markdown_text="Final text"))
+        asyncio.run(streamer.stop())
+        assert streamer._accumulated == "Final text"
+        assert streamer._buffer == ""
+
+    def test_stop_with_cards(self):
+        service = MagicMock()
+        execute_mock = MagicMock()
+        service.spaces().messages().update().execute = execute_mock
+        streamer = GChatStreamer(service, "spaces/test", "spaces/test/messages/123", "thread-1")
+
+        asyncio.run(streamer.append(markdown_text="Done"))
+        cards = [{"cardId": "meta", "card": {"sections": []}}]
+        asyncio.run(streamer.stop(blocks=cards))
+        assert streamer._accumulated == "Done"

--- a/tests/test_gchat_routes.py
+++ b/tests/test_gchat_routes.py
@@ -53,3 +53,171 @@ class TestGChatAddedToSpace:
         assert resp.status_code == 200
         body = resp.json()
         assert "text" in body or "cardsV2" in body
+
+
+class TestGChatSlashCommands:
+    """Test slash command routing through the HTTP endpoint."""
+
+    def _post_slash(self, monkeypatch, command_id, text=""):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        body = {
+            "type": "MESSAGE",
+            "message": {
+                "slashCommand": {"commandId": str(command_id)},
+                "argumentText": text,
+            },
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            return client.post(
+                ENDPOINT,
+                json=body,
+                headers={"Authorization": "Bearer valid"},
+            )
+
+    def test_remember_command(self, monkeypatch, tmp_path):
+        from sandstorm.memory import MemoryStore
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        with patch("sandstorm.gchat.memory_store", store):
+            resp = self._post_slash(monkeypatch, 1, "likes coffee")
+        assert resp.status_code == 200
+        assert "Remembered" in resp.json()["text"]
+
+    def test_memories_command(self, monkeypatch, tmp_path):
+        from sandstorm.memory import MemoryStore
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        with patch("sandstorm.gchat.memory_store", store):
+            resp = self._post_slash(monkeypatch, 5)
+        assert resp.status_code == 200
+        assert "No memories" in resp.json()["text"]
+
+    def test_forget_command(self, monkeypatch, tmp_path):
+        from sandstorm.memory import MemoryStore
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        with patch("sandstorm.gchat.memory_store", store):
+            resp = self._post_slash(monkeypatch, 4, "nonexistent")
+        assert resp.status_code == 200
+        assert "No memory matched" in resp.json()["text"]
+
+    def test_cancel_no_active_run(self, monkeypatch, tmp_path):
+        from sandstorm.store import RunStore
+        store = RunStore(path=tmp_path / "runs.jsonl")
+        with patch("sandstorm.gchat.run_store", store):
+            resp = self._post_slash(monkeypatch, 7)
+        assert resp.status_code == 200
+        assert "no in-flight run" in resp.json()["text"].lower()
+
+    def test_unknown_command(self, monkeypatch):
+        resp = self._post_slash(monkeypatch, 99)
+        assert resp.status_code == 200
+        assert "Unknown" in resp.json()["text"]
+
+
+class TestGChatCardClicked:
+    """Test CARD_CLICKED event handling."""
+
+    def _post_card_click(self, monkeypatch, method_name, params):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        body = {
+            "type": "CARD_CLICKED",
+            "action": {
+                "actionMethodName": method_name,
+                "parameters": [{"key": k, "value": v} for k, v in params.items()],
+            },
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            return client.post(
+                ENDPOINT,
+                json=body,
+                headers={"Authorization": "Bearer valid"},
+            )
+
+    def test_feedback_positive(self, monkeypatch, tmp_path):
+        from sandstorm.store import RunStore
+        store = RunStore(path=tmp_path / "runs.jsonl")
+        with patch("sandstorm.store.run_store", store):
+            resp = self._post_card_click(
+                monkeypatch, "sandstorm_feedback",
+                {"run_id": "abc123", "sentiment": "positive"},
+            )
+        assert resp.status_code == 200
+        assert "Feedback" in resp.json().get("text", "")
+
+    def test_feedback_negative(self, monkeypatch, tmp_path):
+        from sandstorm.store import RunStore
+        store = RunStore(path=tmp_path / "runs.jsonl")
+        with patch("sandstorm.store.run_store", store):
+            resp = self._post_card_click(
+                monkeypatch, "sandstorm_feedback",
+                {"run_id": "abc123", "sentiment": "negative"},
+            )
+        assert resp.status_code == 200
+        assert "Feedback" in resp.json().get("text", "")
+
+    def test_cancel_run(self, monkeypatch):
+        with patch("sandstorm.cancellation.request_cancellation", return_value=True) as mock_cancel:
+            resp = self._post_card_click(
+                monkeypatch, "sandstorm_cancel_run",
+                {"run_id": "run123"},
+            )
+        assert resp.status_code == 200
+        assert "Cancelled" in resp.json().get("text", "") or "Cancel" in resp.json().get("text", "")
+
+    def test_forget_memory(self, monkeypatch, tmp_path):
+        from sandstorm.memory import MemoryStore
+        store = MemoryStore(path=tmp_path / "mem.jsonl")
+        with patch("sandstorm.memory.memory_store", store):
+            resp = self._post_card_click(
+                monkeypatch, "sandstorm_forget_memory",
+                {"memory_id": "mem123"},
+            )
+        assert resp.status_code == 200
+
+
+class TestGChatAppHome:
+    def test_returns_cards_v2(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        body = {
+            "type": "APP_HOME",
+            "user": {"name": "users/123"},
+            "space": {"name": "spaces/abc"},
+        }
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            resp = client.post(
+                ENDPOINT,
+                json=body,
+                headers={"Authorization": "Bearer valid"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "cardsV2" in data
+
+
+class TestGChatErrorHandling:
+    def test_empty_body_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            resp = client.post(
+                ENDPOINT,
+                json={},
+                headers={"Authorization": "Bearer valid"},
+            )
+        assert resp.status_code == 200
+
+    def test_unknown_event_type(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            resp = client.post(
+                ENDPOINT,
+                json={"type": "SOME_FUTURE_EVENT"},
+                headers={"Authorization": "Bearer valid"},
+            )
+        assert resp.status_code == 200

--- a/tests/test_gchat_routes.py
+++ b/tests/test_gchat_routes.py
@@ -159,14 +159,44 @@ class TestGChatCardClicked:
         assert resp.status_code == 200
         assert "Feedback" in resp.json().get("text", "")
 
-    def test_cancel_run(self, monkeypatch):
-        with patch("sandstorm.cancellation.request_cancellation", return_value=True) as mock_cancel:
+    def test_cancel_run_ownership_check(self, monkeypatch, tmp_path):
+        from sandstorm.store import RunStore
+
+        store = RunStore(path=tmp_path / "runs.jsonl")
+        store.create(
+            id="run123", prompt="test", model="sonnet",
+            files_count=0, raw_prompt="test",
+            team_id="spaces/abc", user_id="users/123",
+            channel_id="spaces/abc", thread_ts="t1",
+        )
+        with (
+            patch("sandstorm.store.run_store", store),
+            patch("sandstorm.cancellation.request_cancellation", return_value=True),
+        ):
             resp = self._post_card_click(
                 monkeypatch, "sandstorm_cancel_run",
                 {"run_id": "run123"},
             )
         assert resp.status_code == 200
-        assert "Cancelled" in resp.json().get("text", "") or "Cancel" in resp.json().get("text", "")
+        assert "Cancelled" in resp.json().get("text", "")
+
+    def test_cancel_run_wrong_user(self, monkeypatch, tmp_path):
+        from sandstorm.store import RunStore
+
+        store = RunStore(path=tmp_path / "runs.jsonl")
+        store.create(
+            id="run456", prompt="test", model="sonnet",
+            files_count=0, raw_prompt="test",
+            team_id="spaces/abc", user_id="users/999",
+            channel_id="spaces/abc", thread_ts="t1",
+        )
+        with patch("sandstorm.store.run_store", store):
+            resp = self._post_card_click(
+                monkeypatch, "sandstorm_cancel_run",
+                {"run_id": "run456"},
+            )
+        assert resp.status_code == 200
+        assert "not yours" in resp.json().get("text", "").lower() or "not found" in resp.json().get("text", "").lower()
 
     def test_forget_memory(self, monkeypatch, tmp_path):
         from sandstorm.memory import MemoryStore

--- a/tests/test_gchat_routes.py
+++ b/tests/test_gchat_routes.py
@@ -1,0 +1,55 @@
+"""Tests for the Google Chat events route (gchat_routes.py)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sandstorm.main import app
+
+client = TestClient(app)
+
+ENDPOINT = "/gchat/events"
+
+
+class TestGChatEventsGate:
+    def test_returns_503_without_service_account(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", raising=False)
+        resp = client.post(ENDPOINT, json={"type": "MESSAGE"})
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["error"]
+
+
+class TestGChatEventsAuth:
+    def test_returns_401_without_auth_header(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=False):
+            resp = client.post(ENDPOINT, json={"type": "MESSAGE"})
+        assert resp.status_code == 401
+
+    def test_accepts_valid_jwt(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            resp = client.post(
+                ENDPOINT,
+                json={"type": "ADDED_TO_SPACE", "space": {"name": "spaces/test"}},
+                headers={"Authorization": "Bearer valid-token"},
+            )
+        assert resp.status_code == 200
+
+
+class TestGChatAddedToSpace:
+    def test_returns_welcome_message(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "/tmp/fake.json")
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_NUMBER", "123456")
+        with patch("sandstorm.gchat_routes._verify_google_chat_jwt", return_value=True):
+            resp = client.post(
+                ENDPOINT,
+                json={"type": "ADDED_TO_SPACE", "space": {"name": "spaces/test"}},
+                headers={"Authorization": "Bearer valid-token"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "text" in body or "cardsV2" in body

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,5 +1,9 @@
 """Tests for the shared platform core (platform.py)."""
 
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
 from sandstorm.platform import (
     build_query_request,
     gather_thread_context,
@@ -86,6 +90,56 @@ class TestUniqueFilename:
 
 import asyncio
 from sandstorm.platform import SandboxPoolManager
+
+
+class TestStreamBridge:
+    def _make_async_generator(self, events: list[str]):
+        async def gen(request, request_id="", **kwargs):
+            for event in events:
+                yield event
+        return gen
+
+    def test_assistant_text_dispatched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+        from sandstorm.platform import StreamBridge
+        events = [
+            json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello"}]}}),
+            json.dumps({"type": "result", "subtype": "end_turn", "num_turns": 1, "total_cost_usd": 0.01, "model": "sonnet"}),
+        ]
+        gen = self._make_async_generator(events)
+        streamer = AsyncMock()
+        streamer.append = AsyncMock()
+        streamer.stop = AsyncMock()
+        from sandstorm.store import RunStore
+        request = build_query_request("test")
+        bridge = StreamBridge(streamer, run_store=RunStore(path=tmp_path / "runs.jsonl"))
+
+        with patch("sandstorm.platform.run_agent_in_sandbox", gen):
+            result = asyncio.run(bridge.run(request, "run1", AsyncMock(), "C001", "ts1"))
+
+        streamer.append.assert_called()
+        streamer.stop.assert_called()
+        assert result["model"] == "sonnet"
+        assert result["cost_usd"] == 0.01
+
+    def test_error_event_records_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+        from sandstorm.platform import StreamBridge
+        events = [json.dumps({"type": "error", "error": "Sandbox timeout"})]
+        gen = self._make_async_generator(events)
+        streamer = AsyncMock()
+        streamer.append = AsyncMock()
+        streamer.stop = AsyncMock()
+        from sandstorm.store import RunStore
+        request = build_query_request("test")
+        bridge = StreamBridge(streamer, run_store=RunStore(path=tmp_path / "runs.jsonl"))
+
+        with patch("sandstorm.platform.run_agent_in_sandbox", gen):
+            result = asyncio.run(bridge.run(request, "run2", AsyncMock(), "C001", "ts1"))
+
+        assert result["error"] == "Sandbox timeout"
 
 
 class TestSandboxPoolManager:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -82,3 +82,41 @@ class TestUniqueFilename:
         seen: set[str] = set()
         unique_filename("README", seen)
         assert unique_filename("README", seen) == "README_1"
+
+
+import asyncio
+from sandstorm.platform import SandboxPoolManager
+
+
+class TestSandboxPoolManager:
+    def test_get_or_create_returns_none_for_new_key(self):
+        pool = SandboxPoolManager(max_size=10)
+        sandbox_id, lock = asyncio.run(pool.get_or_create("tenant", "chan", "ts"))
+        assert sandbox_id is None
+        assert lock is not None
+
+    def test_update_stores_sandbox_id(self):
+        pool = SandboxPoolManager(max_size=10)
+        asyncio.run(pool.get_or_create("tenant", "chan", "ts"))
+        pool.update("tenant", "chan", "ts", "sbx-123")
+        sandbox_id, _ = asyncio.run(pool.get_or_create("tenant", "chan", "ts"))
+        assert sandbox_id == "sbx-123"
+
+    def test_clear_resets_sandbox_id(self):
+        pool = SandboxPoolManager(max_size=10)
+        asyncio.run(pool.get_or_create("tenant", "chan", "ts"))
+        pool.update("tenant", "chan", "ts", "sbx-123")
+        pool.clear("tenant", "chan", "ts")
+        sandbox_id, _ = asyncio.run(pool.get_or_create("tenant", "chan", "ts"))
+        assert sandbox_id is None
+
+    def test_evicts_oldest_when_full(self):
+        pool = SandboxPoolManager(max_size=2)
+        asyncio.run(pool.get_or_create("t", "c", "ts1"))
+        pool.update("t", "c", "ts1", "sbx-1")
+        asyncio.run(pool.get_or_create("t", "c", "ts2"))
+        pool.update("t", "c", "ts2", "sbx-2")
+        # Adding a third should evict the first
+        asyncio.run(pool.get_or_create("t", "c", "ts3"))
+        pool.evict_if_needed()
+        assert pool.size() <= 2

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,84 @@
+"""Tests for the shared platform core (platform.py)."""
+
+from sandstorm.platform import (
+    build_query_request,
+    gather_thread_context,
+    unique_filename,
+)
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_required_env_vars(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    monkeypatch.setenv("E2B_API_KEY", "e2b-test-key")
+
+
+class TestBuildQueryRequest:
+    def test_uses_env_defaults(self):
+        request = build_query_request("hello world")
+        assert request.prompt == "hello world"
+        assert request.timeout is None
+        assert request.model is None
+        assert request.output_format == {}
+
+    def test_attaches_files(self):
+        files = {"data.csv": "a,b\n1,2"}
+        request = build_query_request("analyze this", files)
+        assert request.files == {"data.csv": "a,b\n1,2"}
+
+    def test_scoped_memory_fields_passthrough(self):
+        request = build_query_request(
+            "hi", team_id="T1", user_id="U1", model="claude-haiku-4-5-20251001"
+        )
+        assert request.team_id == "T1"
+        assert request.user_id == "U1"
+        assert request.model == "claude-haiku-4-5-20251001"
+
+
+class TestGatherThreadContext:
+    def test_formats_thread_messages(self):
+        messages = [
+            {"user": "U001", "text": "Hey there"},
+            {"user": "BBOT", "text": "Working on it..."},
+        ]
+        result = gather_thread_context(messages, "BBOT")
+        assert "[U001] Hey there" in result
+        assert "[Sandstorm] Working on it..." in result
+
+    def test_includes_file_attachments(self):
+        messages = [
+            {
+                "user": "U001",
+                "text": "",
+                "files": [{"name": "data.csv", "mimetype": "text/csv", "size": 15360}],
+            },
+        ]
+        result = gather_thread_context(messages, "BBOT")
+        assert "[attached: data.csv (text/csv, 15KB)]" in result
+
+    def test_empty_messages(self):
+        result = gather_thread_context([], "BBOT")
+        assert result == ""
+
+    def test_uses_display_names_when_provided(self):
+        messages = [{"user": "U001", "text": "Hey there"}]
+        user_names = {"U001": "Alice"}
+        result = gather_thread_context(messages, "BBOT", user_names=user_names)
+        assert "[Alice] Hey there" in result
+
+
+class TestUniqueFilename:
+    def test_first_use_unchanged(self):
+        seen: set[str] = set()
+        assert unique_filename("file.txt", seen) == "file.txt"
+
+    def test_duplicate_gets_suffix(self):
+        seen: set[str] = set()
+        unique_filename("file.txt", seen)
+        assert unique_filename("file.txt", seen) == "file_1.txt"
+
+    def test_no_extension(self):
+        seen: set[str] = set()
+        unique_filename("README", seen)
+        assert unique_filename("README", seen) == "README_1"

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -447,7 +447,7 @@ class TestStreamToSlack:
         request = _build_query_request("test prompt")
 
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             result = asyncio.run(
@@ -476,7 +476,7 @@ class TestStreamToSlack:
         set_status = AsyncMock()
 
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(
@@ -502,7 +502,7 @@ class TestStreamToSlack:
         request = _build_query_request("test")
 
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             result = asyncio.run(
@@ -540,7 +540,7 @@ class TestStreamToSlack:
         request = _build_query_request("test prompt")
 
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(
@@ -572,7 +572,7 @@ class TestStreamToSlack:
         set_status = AsyncMock()
 
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             result = asyncio.run(
@@ -663,7 +663,7 @@ class TestStreamToSlackSandboxParams:
 
         request = _build_query_request("test")
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(
@@ -691,7 +691,7 @@ class TestStreamToSlackSandboxParams:
 
         request = _build_query_request("test")
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(
@@ -721,7 +721,7 @@ class TestStreamToSlackSandboxParams:
         request = _build_query_request("test")
         sandbox_id_out: list[str] = []
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(
@@ -750,7 +750,7 @@ class TestStreamToSlackSandboxParams:
         request = _build_query_request("test")
         binary = {"photo.png": b"\x89PNG\r\n"}
         with (
-            patch("sandstorm.slack.run_agent_in_sandbox", gen),
+            patch("sandstorm.platform.run_agent_in_sandbox", gen),
             patch("sandstorm.slack.run_store", RunStore(path=tmp_path / "runs.jsonl")),
         ):
             asyncio.run(


### PR DESCRIPTION
# Google Chat Integration

## Summary

Adds Google Chat as a second chat platform for Sandstorm, matching ~90% of the existing Slack integration's feature set. Users can deploy Sandstorm to Google Workspace organizations alongside or instead of Slack.

This PR introduces:

- **Platform abstraction layer** — shared utilities extracted from the Slack adapter into `platform.py`, enabling both integrations to share streaming, sandbox pooling, file handling, and thread context logic
- **Google Chat adapter** — event routing, slash commands, App Home (Cards v2), file handling, reaction triggers, streamed responses via post-then-edit
- **CLI tooling** — `ds gchat setup/verify/start/test` commands for onboarding and operations
- **Full test coverage** — 60+ new tests across platform, adapter, routes, and CLI layers

## What's included

### Platform abstraction (`platform.py`)

Extracted from `slack.py` to be shared across integrations:

| Component | Purpose |
|-----------|---------|
| `StreamBridge` | Consumes `run_agent_in_sandbox()` SSE events, dispatches to any duck-typed streamer via `append(markdown_text=...)` / `stop(blocks=...)` |
| `SandboxPoolManager` | Thread-safe sandbox reuse pool with LRU eviction — one sandbox per conversation thread |
| `build_query_request()` | Builds `QueryRequest` from prompt + files, deferring model/timeout to `sandstorm.json` |
| `gather_thread_context()` | Formats normalized `{user, text, files}` message dicts into a context string |
| `unique_filename()` | Deduplicates filenames across thread attachments |

`slack.py` was refactored to import these shared utilities (net -351 lines), with zero behavioral changes to the Slack integration.

### Google Chat adapter

| Component | File | Description |
|-----------|------|-------------|
| Event routing | `gchat_routes.py` | FastAPI router at `/gchat/events` with JWT verification, event dispatch |
| Core adapter | `gchat.py` | `GChatStreamer`, event type parsing, metadata cards, slash command dispatch, file handling, thread fetching |
| App Home | `gchat_app_home.py` | Cards v2 rendering: status, active run cancel, memories with forget buttons, space defaults, triggers |
| CLI | `cli.py` | `ds gchat setup` (interactive wizard), `verify` (preflight checks), `start` (FastAPI server), `test` (live integration test) |

### Feature parity with Slack

| Feature | Status |
|---------|--------|
| Streamed responses | Post-then-edit with 2s batching (Google Chat has no native streaming) |
| File uploads (text + binary) | Via Google Chat attachment API, up to 50 MB |
| Sandbox reuse per thread | Shared `SandboxPoolManager` |
| Thread context | Full conversation history passed to agent |
| File extraction from sandbox | Upload back to thread |
| Feedback buttons (thumbs up/down) | Cards v2 interactive buttons |
| Metadata footer | Model, turns, cost, duration in Cards v2 |
| Per-space default agent | Via `sandstorm.json` channels config |
| App Home | Cards v2 with status, cancel, memories, defaults, triggers |
| Slash commands | `/remember`, `/team_remember`, `/channel_remember`, `/forget`, `/memories`, `/cancel` |
| Reaction triggers | Emoji normalization + trigger matching wired up |
| Cancel in-flight runs | Slash command + App Home button with ownership verification |
| Three-level memory | User, team, and channel (space) scopes |

### Not yet wired up

The agent dispatch pipeline for `MESSAGE` events (@mention and DM) and reaction trigger agent runs are **not connected in this PR**. All the infrastructure is in place (streaming, file handling, sandbox pooling, thread context), but the final step of calling `StreamBridge.run()` from the message handler will come in a follow-up PR. This keeps the PR focused on the adapter layer and platform abstraction.

## Architecture

```
Google Chat HTTP push
        │
        ▼
  /gchat/events  (FastAPI, JWT verified)
        │
        ▼
  _dispatch_event()
        │
  ┌─────┼─────────────────┐
  │     │                  │
  ▼     ▼                  ▼
slash  card_clicked     reaction
cmd    (feedback,        (emoji →
       cancel,           shortcode →
       forget)           trigger match)
  │     │                  │
  ▼     ▼                  ▼
memory  run_store /      triggers.py
store   cancellation
```

## Auth model

- **Incoming events**: JWT verification via `google.oauth2.id_token.verify_token()` with audience = `GOOGLE_CHAT_PROJECT_NUMBER` and issuer = `chat@system.gserviceaccount.com`
- **Outgoing API calls**: Service account JSON key file (`GOOGLE_CHAT_SERVICE_ACCOUNT_KEY`)
- **Cancel ownership**: Card-click cancel verifies `team_id` + `user_id` match the run before cancelling

## Dependencies

New optional extra in `pyproject.toml`:

```toml
[project.optional-dependencies]
gchat = [
    "google-api-python-client>=2.100.0",
    "google-auth>=2.25.0",
    "google-auth-httplib2>=0.2.0",
]
```

Install with `pip install "duvo-sandstorm[gchat]"`. Zero new required dependencies — Google packages are opt-in.

## Testing

- **60+ new tests** across `test_platform.py` (16), `test_gchat.py` (26), `test_gchat_routes.py` (17), `test_cli.py` (2)
- **Zero Slack regressions** — all existing `test_slack.py` tests pass with updated import paths
- **421 tests passing** total (4 pre-existing failures unrelated to this PR)

```
tests/test_platform.py       16 passed
tests/test_gchat.py           26 passed
tests/test_gchat_routes.py    17 passed
tests/test_cli.py              2 new tests passed
tests/test_slack.py           all passing (import paths updated)
```

## File changes

```
 16 files changed, 4147 insertions(+), 351 deletions(-)
```

| File | Change |
|------|--------|
| `src/sandstorm/platform.py` | **New** — shared platform abstractions |
| `src/sandstorm/gchat.py` | **New** — Google Chat adapter |
| `src/sandstorm/gchat_routes.py` | **New** — FastAPI event router |
| `src/sandstorm/gchat_app_home.py` | **New** — App Home Cards v2 |
| `src/sandstorm/cli.py` | **Modified** — added `ds gchat` command group |
| `src/sandstorm/main.py` | **Modified** — mount gchat router |
| `src/sandstorm/slack.py` | **Modified** — refactored to use `platform.py` (-351 lines) |
| `pyproject.toml` | **Modified** — added `gchat` optional extra |
| `docs/gchat.md` | **New** — user-facing documentation |
| `tests/test_platform.py` | **New** — 16 tests |
| `tests/test_gchat.py` | **New** — 26 tests |
| `tests/test_gchat_routes.py` | **New** — 17 tests |
| `tests/test_cli.py` | **Modified** — 2 new tests |
| `tests/test_slack.py` | **Modified** — updated patch targets |

## How to test

```bash
# Install with Google Chat extra
pip install -e ".[gchat,dev]"

# Run all tests
pytest tests/ -v

# Run only Google Chat tests
pytest tests/test_gchat.py tests/test_gchat_routes.py tests/test_platform.py -v

# Preflight check (without deploying)
ds gchat verify
```

## Documentation

Full setup and usage guide at [`docs/gchat.md`](../gchat.md) covering:
- GCP project setup (Chat API, service account, app configuration)
- Interactive setup wizard (`ds gchat setup`)
- Usage patterns (mentions, DMs, threads, slash commands)
- Feature list with current status
- Environment variables and `sandstorm.json` configuration
- Production deployment (HTTPS, reverse proxy)
- CLI reference